### PR TITLE
feat: add projects section to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,16 @@
       <p>I'm a Senior Product Manager at <a href="https://dojo.tech">Dojo</a>. In the past, I worked at the <a href="https://www.ft.com">FT</a> and <a href="https://www.fathom.global">Fathom</a>. I've gained experience in payments, news media, and climate-tech. I'm passionate about building products, venture capital and revenue growth. I hold a <a href="https://scholar.google.com/citations?user=kTGvKsMAAAAJ">PhD</a> in Physical Geography. Connect on <a href="https://github.com/jsosa">GitHub</a>, <a href="https://x.com/jsosaxyz">X</a>, <a href="https://www.linkedin.com/in/jsosaxyz/">LinkedIn</a> or reach me at <span style="user-select: none; -webkit-user-select: none; -moz-user-select: none;">me@jsosa.xyz</span></p>
     </section>
 
+    <section id="projects">
+      <h2>Projects</h2>
+      <div class="project-list">
+        <a class="project-item" href="profitable.html">
+          <span class="project-title">Profitable</span>
+          <span class="project-description">A lightweight calculator for modelling profit, margin, and unit economics.</span>
+        </a>
+      </div>
+    </section>
+
     <section id="writing">
       <h2>Writing</h2>
       <p>I wanted to read essays about the things I find interesting, in the format and prose I enjoy. So I started making my own. For each topic, I ingest 10 to 20 articles, papers, and datasets, store everything in markdown, and have Claude to write the essay for me. Once done, I run a strict fact-check against the source material</p>

--- a/style.css
+++ b/style.css
@@ -190,6 +190,38 @@ section:last-of-type {
   line-height: 1.4;
 }
 
+/* ─── Project list ───────────────────────────── */
+
+.project-list {
+  margin: 25px 0 0;
+}
+
+.project-item {
+  display: block;
+  padding: 14px 0 16px;
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+}
+
+.project-item:hover {
+  border-top-color: var(--rule);
+  border-bottom-color: var(--ink);
+}
+
+.project-title {
+  display: block;
+  font-size: 15px;
+  line-height: 1.4;
+  margin-bottom: 4px;
+}
+
+.project-description {
+  display: block;
+  color: var(--gray);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
 /* ─── Meta ───────────────────────────────────── */
 
 .meta {


### PR DESCRIPTION
## Summary
- Add a Projects section to the homepage
- List Profitable as the first project
- Reorder homepage sections to About, Projects, then Writing
- Add project-list styling to match the existing minimalist design

## Test Plan
- Parsed index.html with Python HTMLParser
- Previewed locally with python3 -m http.server
- Visually verified the homepage section order and spacing