### PR TITLE
feat: add Hermes article

### DIFF
--- a/hermes-on-my-desk.html
+++ b/hermes-on-my-desk.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Hermes on my desk | Jeison Sosa</title>
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="stylesheet" href="style.css">
+  </head>
+  <body>
+    <a href="/" class="back-link">← Home</a>
+
+    <article>
+      <h1>Hermes on my desk</h1>
+      <p class="meta">26 May 2026</p>
+
+      <p>At first, Hermes lived on a small Hostinger VPS. That made sense. It was cheap, always on, and far enough away that I could treat it like infrastructure rather than another app on my laptop.</p>
+
+      <p>The problem was ownership. I already rely on OpenAI and Claude, and I accept that some of my data moves through their systems when I use their models. With the VPS, there was a third party in the middle as well: the host running the machine that held the agent, the logs, the files, and the routines.</p>
+
+      <p>That started to feel wrong. The whole point of Hermes was not just to chat, but to act: read local files, edit projects, remember preferences, run scheduled tasks, and connect different parts of my work. If an agent is going to sit that close to your life, the machine matters.</p>
+
+      <p>So I moved it to a Mac mini. The migration was not grand. It was the plain work of copying config, moving skills, restoring memories, checking cron jobs, wiring Telegram again, and making sure the same agent could wake up in a new place without losing its shape.</p>
+
+      <p>The Mac mini changed the feeling of the system. Hermes became part of the room: a small box on my desk with my files beside it, my repos within reach, and the gateway open through Telegram. I could restart it, patch it, inspect it, and know where the work was happening.</p>
+
+      <p>GitHub sync became the safety rail. The agent now backs up the parts that matter: config, skills, memories, cron definitions, and project state that should survive a bad update or a dead disk. It is not glamorous, but it is the difference between a toy and a tool you can trust.</p>
+
+      <p>The sync also makes the system easier to reason about. Changes are not just hidden inside a local folder. They become commits, diffs, and a history of how the agent has changed over time.</p>
+
+      <p>The Press Library added another layer. Instead of asking one model to know the whole web, Hermes can pick up small tools for specific corners of it: Substack, Airbnb, Booking, Food52, and whatever gets added next. It turns the agent from a chat box into a workbench.</p>
+
+      <p>Most of the value has come from ordinary work. We have edited this site, opened pull requests, built backup routines, fixed cron delivery, drafted essays, and started shaping company-performance trackers. None of it feels dramatic on its own. Together it lowers the cost of doing small, useful things.</p>
+
+      <p>That is the real shift. Hermes is not a second brain. It is closer to a patient operator: close enough to the work, grounded enough in the tools, and persistent enough to keep going while the idea is still warm.</p>
+
+      <p>The question is no longer whether an agent can help. It is where it should live, what it should remember, and which parts of your life are worth putting within reach.</p>
+    </article>
+
+    <footer>
+      <span>© 2026 Jeison Sosa</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -35,6 +35,10 @@
       <p>I wanted to read essays about the things I find interesting, in the format and prose I enjoy. So I started making my own. For each topic, I ingest 10 to 20 articles, papers, and datasets, store everything in markdown, and have Claude to write the essay for me. Once done, I run a strict fact-check against the source material</p>
       <div class="post-list">
         <div class="post-item">
+          <span class="post-date">26 May 2026</span>
+          <a href="hermes-on-my-desk.html">Hermes on my desk</a>
+        </div>
+        <div class="post-item">
           <span class="post-date">24 Apr 2026</span>
           <a href="ai-moving-to-your-device.html">Why AI is moving to your device</a>
         </div>


### PR DESCRIPTION
## Summary
- Adds a new essay page, `Hermes on my desk`
- Links it from the homepage Writing section
- Covers the move from Hostinger VPS to Mac mini, GitHub sync, Press Library, and recent Hermes workflows

## Verification
- Parsed homepage and article HTML locally
- Checked article prose constraints and excluded job-search references
- Rendered locally with the existing static-site server
