### PR TITLE
feat: add public wiki export

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,10 @@
     <section id="projects">
       <h2>Projects</h2>
       <div class="project-list">
+        <a class="project-item" href="wiki/">
+          <span class="project-title">Wiki</span>
+          <span class="project-description">A public map of concepts, companies, people, markets, and operating ideas I'm learning from.</span>
+        </a>
         <a class="project-item" href="profitable.html">
           <span class="project-title">Profitable</span>
           <span class="project-description">A lightweight calculator for modelling profit, margin, and unit economics.</span>

--- a/wiki/concepts/agent-maintained-knowledge-base.html
+++ b/wiki/concepts/agent-maintained-knowledge-base.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Agent-Maintained Knowledge Base · Jay Sosa Wiki</title>
+    <meta name="description" content="An agent-maintained knowledge base is a repository where the LLM is responsible for the repetitive maintenance work: summarising, filing, cross-linking, updating pages, flagging contradictions, and keeping...">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/concepts/agent-maintained-knowledge-base.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-concept">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Concept</p>
+      <h1>Agent-Maintained Knowledge Base</h1>
+      <p class="meta">Concept · Updated 2026-05-27 · Confidence: high</p>
+      <div class="wiki-tags"><span>knowledge-base</span><span>agent-workflow</span><span>llm</span><span>research</span></div>
+      <div class="wiki-content">
+<p>An agent-maintained knowledge base is a repository where the LLM is responsible for the repetitive maintenance work: summarising, filing, cross-linking, updating pages, flagging contradictions, and keeping indexes/logs current.</p>
+<p>The human remains responsible for source selection, emphasis, taste, and final judgement. The agent handles the maintenance burden that usually causes personal wikis to decay.</p>
+<h2 id="what-the-agent-does">What the agent does</h2>
+<ul>
+<li>Reads new sources and extracts durable claims.</li>
+<li>Updates existing entity and concept pages.</li>
+<li>Creates new pages only when a topic deserves to become a durable node.</li>
+<li>Maintains <code>index.md</code> and <code>log.md</code>.</li>
+<li>Flags contradictions rather than silently overwriting them.</li>
+<li>Files substantial query answers back into the wiki.</li>
+</ul>
+<h2 id="why-this-is-different-from-note-taking">Why this is different from note-taking</h2>
+<p>The user does not need to manually write and maintain every note. The wiki becomes closer to a codebase: the schema is the spec, Obsidian or a text editor is the IDE, and the LLM is the maintainer making structured edits.</p>
+<h2 id="risks">Risks</h2>
+<ul>
+<li>Over-creating pages for minor mentions.</li>
+<li>Letting weak single-source claims harden into facts.</li>
+<li>Failing to update the index/log.</li>
+<li>Creating links without preserving provenance.</li>
+</ul>
+      </div>
+    </article>
+
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/concepts/ai-era-product-management.html
+++ b/wiki/concepts/ai-era-product-management.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>AI-era Product Management · Jay Sosa Wiki</title>
+    <meta name="description" content="Gokul Rajaram argues that AI changes product management because software is becoming faster, cheaper, and less deterministic to build. The durable human role is judgement: choosing what matters, defining the customer...">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/concepts/ai-era-product-management.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-concept">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Concept</p>
+      <h1>AI-era Product Management</h1>
+      <p class="meta">Concept · Updated 2026-05-28 · Confidence: medium</p>
+      <div class="wiki-tags"><span>product</span><span>ai</span><span>strategy</span><span>operator</span></div>
+      <div class="wiki-content">
+<p>Gokul Rajaram argues that AI changes product management because software is becoming faster, cheaper, and less deterministic to build. The durable human role is judgement: choosing what matters, defining the customer behaviour change, and evaluating whether AI-generated output is good enough.</p>
+<h2 id="pm-as-keeper-of-the-why">PM as keeper of the why</h2>
+<p>Rajaram's core product definition is balancing customer needs and business needs. Every feature should have a hypothesis stated as a customer behaviour change: users go from doing X to doing Y, from spending X minutes to Y minutes, or from one customer state to another. The PM protects this why while engineers, researchers, designers, and PMs increasingly build prototypes together.</p>
+<h2 id="pms-must-become-hands-on">PMs must become hands-on</h2>
+<p>Rajaram says PMs are starting to check code into production repositories with tools like Claude Code and Codex, subject to review. Product and design roles are also converging as AI can work within established design systems. The product manager of the AI era needs enough hands-on fluency to prototype, evaluate, and challenge the capability frontier rather than simply write specs.</p>
+<h2 id="non-deterministic-products-need-evals">Non-deterministic products need evals</h2>
+<p>AI software can respond differently to small input variations. That makes evaluation a core product responsibility. PMs and researchers need to design evals, including AI-assisted evals, to test whether outputs are useful, safe, and shippable across important use cases.</p>
+<h2 id="future-proof-skill-judgement">Future-proof skill: judgement</h2>
+<p>When a thousand AI agents can write code, the scarce question is not whether something can be built but whether it should be built. Judgement applies to product priorities, code review, design coherence, and customer-value trade-offs.</p>
+      </div>
+    </article>
+
+    <section class="wiki-related">
+      <h2>Related pages</h2>
+      <ul><li><a href="../concepts/startup-operating-and-management.html">Startup Operating and Management</a></li></ul>
+    </section>
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/concepts/ai-founder-mode.html
+++ b/wiki/concepts/ai-founder-mode.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>AI Founder Mode · Jay Sosa Wiki</title>
+    <meta name="description" content="Brian Chesky describes founder mode as the founder/CEO staying close enough to the work to steer the company, rather than over-delegating to professional managers and being managed by the organisation. AI founder...">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/concepts/ai-founder-mode.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-concept">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Concept</p>
+      <h1>AI Founder Mode</h1>
+      <p class="meta">Concept · Updated 2026-05-28 · Confidence: medium</p>
+      <div class="wiki-tags"><span>operator</span><span>company</span><span>strategy</span><span>ai</span></div>
+      <div class="wiki-content">
+<p>Brian Chesky describes founder mode as the founder/CEO staying close enough to the work to steer the company, rather than over-delegating to professional managers and being managed by the organisation. AI founder mode raises the bar: if AI reduces the cost of information, prototyping, and execution, the leader can operate with fewer abstraction layers and more direct contact with the work.</p>
+<h2 id="core-operating-pattern">Core operating pattern</h2>
+<p>Chesky's pre-AI founder mode used live group reviews with the full chain of command in the room. He did not rely on one-on-ones as the main operating system; he reviewed the work, listened first, usually agreed with the team, and ratified or corrected decisions. His principle is to start hands-on, learn what is happening, teach the organisation the right muscle memory, and then give ground grudgingly.</p>
+<p>AI founder mode shifts some of that from meeting-based management toward asynchronous inspection, direct artefacts, and faster feedback loops. The CEO or founder should be able to see prototypes, decisions, customer signals, and operational work directly rather than waiting for a hierarchy to summarise them.</p>
+<h2 id="what-changes-in-the-organisation">What changes in the organisation</h2>
+<ul>
+<li>Fewer pure people managers. Chesky argues managers must also be close to the craft: engineers still code, lawyers still read case law, design leaders still design, and operators still operate.</li>
+<li>More manager-IC hybrids. Leadership happens through the work, not only through counselling, coordination, or one-on-ones.</li>
+<li>Fewer layers. The thought experiment is not a totally flat 7,000-person company, but a much thinner organisation where information does not pass through seven to nine layers.</li>
+<li>Higher standards for tool adoption. The near-term job is to get everyone using AI tools, observe how roles change, and then redesign the company around the new reality.</li>
+</ul>
+<h2 id="why-it-matters">Why it matters</h2>
+<p>This updates <a href="../concepts/startup-operating-and-management.html">Startup Operating and Management</a> and <a href="../concepts/later-stage-startup-scaling.html">Later-stage Startup Scaling</a> for AI. The risk of the old model is a game of telephone: the founder gives direction, details pass through layers, and reality is distorted. AI lowers the cost of looking directly at the work, so detachment becomes harder to justify.</p>
+<h2 id="caveats">Caveats</h2>
+<p>Founder mode is not a license for permanent chaos or unstructured micromanagement. Chesky's model is intense early control followed by trained delegation. It works only if the founder uses detail-orientation to build organisational judgement, not to become a bottleneck for every trivial decision.</p>
+      </div>
+    </article>
+
+    <section class="wiki-related">
+      <h2>Related pages</h2>
+      <ul><li><a href="../concepts/startup-operating-and-management.html">Startup Operating and Management</a></li>
+<li><a href="../concepts/later-stage-startup-scaling.html">Later-stage Startup Scaling</a></li>
+<li><a href="../entities/brian-chesky.html">Brian Chesky</a></li></ul>
+    </section>
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/concepts/ai-native-software-business-models.html
+++ b/wiki/concepts/ai-native-software-business-models.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>AI-native Software Business Models · Jay Sosa Wiki</title>
+    <meta name="description" content="Gokul Rajaram&#x27;s AI-software thesis is that thin AI features are fragile, but AI-native companies can be durable when they own scarce assets, deep workflows, systems of record, data loops, regulated control points,...">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/concepts/ai-native-software-business-models.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-concept">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Concept</p>
+      <h1>AI-native Software Business Models</h1>
+      <p class="meta">Concept · Updated 2026-05-28 · Confidence: medium</p>
+      <div class="wiki-tags"><span>ai</span><span>company</span><span>market</span><span>strategy</span><span>investing</span></div>
+      <div class="wiki-content">
+<p>Gokul Rajaram's AI-software thesis is that thin AI features are fragile, but AI-native companies can be durable when they own scarce assets, deep workflows, systems of record, data loops, regulated control points, money movement, hardware, networks, or full-stack vertical platforms.</p>
+<h2 id="from-utility-software-to-work-software">From utility software to work software</h2>
+<p>Seat pricing still works for access products, such as enterprise AI tools sold as predictable per-user tiers. It breaks when the product is doing work on a user's behalf. Work products should move toward outcome pricing: per contract processed, ticket resolved, workflow completed, transaction, or business result.</p>
+<h2 id="systems-of-action-are-not-enough">Systems of action are not enough</h2>
+<p>Rajaram argues that many AI companies initially tried to sit on top of legacy systems of record as systems of action. Incumbents can block APIs, charge for data access, or bundle free agents. Durable AI entrants may need to build or replace the system of record, including the migration tools required to move data from Salesforce, Jira, Zendesk, or similar incumbents.</p>
+<h2 id="vertical-ai-has-to-own-the-stack">Vertical AI has to own the stack</h2>
+<p>A single AI function inside a vertical can be a viable business, but Rajaram doubts it becomes a very large company unless it expands to own the full stack. ServiceTitan is his canonical vertical example: many products, deep workflow, and control over a large operational category.</p>
+<h2 id="bpo-first-hiring-replacement-later">BPO first, hiring replacement later</h2>
+<p>Rajaram expects AI labour replacement to hit outsourced BPO spend first, because that budget is already explicit and easier to cut. Next comes not replacing departing employees. Direct layoffs are the later and more sensitive step.</p>
+<h2 id="what-to-underwrite">What to underwrite</h2>
+<p>The two questions for pure software are: does the company create a proprietary data asset that improves with every interaction, and is it deeply embedded in a workflow that matters? Without that, model improvements and horizontal agent builders can erode the product quickly.</p>
+      </div>
+    </article>
+
+    <section class="wiki-related">
+      <h2>Related pages</h2>
+      <ul><li><a href="../concepts/enterprise-software-startups.html">Enterprise Software Startups</a></li>
+<li><a href="../concepts/software-moats.html">Software Moats</a></li></ul>
+    </section>
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/concepts/barrels-and-ammunition.html
+++ b/wiki/concepts/barrels-and-ammunition.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Barrels and Ammunition · Jay Sosa Wiki</title>
+    <meta name="description" content="Barrels and ammunition is keith-rabois&#x27;s hiring and team-design metaphor. A barrel can take an idea, aim it, assemble the people needed, and ship the outcome. Ammunition is high-quality talent that needs a barrel to...">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/concepts/barrels-and-ammunition.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-concept">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Concept</p>
+      <h1>Barrels and Ammunition</h1>
+      <p class="meta">Concept · Updated 2026-05-28 · Confidence: medium</p>
+      <div class="wiki-tags"><span>operator</span><span>company</span><span>strategy</span></div>
+      <div class="wiki-content">
+<p>Barrels and ammunition is <a href="../entities/keith-rabois.html">Keith Rabois</a>'s hiring and team-design metaphor. A barrel can take an idea, aim it, assemble the people needed, and ship the outcome. Ammunition is high-quality talent that needs a barrel to direct it.</p>
+<h2 id="core-distinction">Core distinction</h2>
+<ul>
+<li><strong>Barrels:</strong> owners, drivers, and integrators. They can turn ambiguous goals into shipped work and bring other people with them.</li>
+<li><strong>Ammunition:</strong> strong contributors with useful energy or skill, but without enough autonomous direction to multiply output alone.</li>
+</ul>
+<h2 id="operating-implication">Operating implication</h2>
+<p>Hiring more people only increases company output if there are enough barrels to aim them. Without barrels, extra ammunition creates coordination load, meetings, confusion, and unfinished projects.</p>
+<h2 id="how-to-use-it">How to use it</h2>
+<p>When evaluating a team or role, ask:</p>
+<ol>
+<li>Who can independently own a problem from diagnosis to shipped result?</li>
+<li>Which teams are talent-rich but barrel-poor?</li>
+<li>Which ICs could become barrels if given wider scope and coaching?</li>
+<li>Is the company hiring more ammunition because it lacks the courage or discipline to find barrels?</li>
+</ol>
+      </div>
+    </article>
+
+    <section class="wiki-related">
+      <h2>Related pages</h2>
+      <ul><li><a href="../entities/keith-rabois.html">Keith Rabois</a></li>
+<li><a href="../concepts/keith-rabois-operating-frameworks.html">Keith Rabois Operating Frameworks</a></li>
+<li><a href="../concepts/startup-hiring-and-culture.html">Startup Hiring and Culture</a></li>
+<li><a href="../concepts/startup-operating-and-management.html">Startup Operating and Management</a></li></ul>
+    </section>
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/concepts/blood-sugar-balancing-for-metabolic-health.html
+++ b/wiki/concepts/blood-sugar-balancing-for-metabolic-health.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Blood Sugar Balancing for Metabolic Health · Jay Sosa Wiki</title>
+    <meta name="description" content="Deering argues that metabolic healing depends on stable fuel availability. Low blood sugar triggers adrenaline, cortisol, and glucagon; excessive spikes trigger insulin and storage. The goal is a steady, warm, calm...">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/concepts/blood-sugar-balancing-for-metabolic-health.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-concept">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Concept</p>
+      <h1>Blood Sugar Balancing for Metabolic Health</h1>
+      <p class="meta">Concept · Updated 2026-05-28 · Confidence: medium</p>
+      <div class="wiki-tags"><span>health</span><span>nutrition</span><span>metabolism</span></div>
+      <div class="wiki-content">
+<p>Deering argues that metabolic healing depends on stable fuel availability. Low blood sugar triggers adrenaline, cortisol, and glucagon; excessive spikes trigger insulin and storage. The goal is a steady, warm, calm state rather than long fasts, black coffee, under-eating, or reactive snacking.</p>
+<h2 id="practical-rules-from-the-book">Practical rules from the book</h2>
+<ul>
+<li>Pair carbohydrates with protein and/or fat: fruit with cheese, milk with fruit, eggs with orange juice, coffee with milk/sugar/gelatin.</li>
+<li>Eat enough at each meal to stay warm, alert, satisfied, and stable for roughly 3–4 hours.</li>
+<li>Adjust meal frequency to liver glycogen capacity and stress state; some people may need frequent small meals during recovery.</li>
+<li>Use temperature, pulse, mood, stool, sleep, appetite, and energy as feedback.</li>
+<li>Avoid black coffee, alcohol, fasting, or hard workouts when they produce stress symptoms.</li>
+</ul>
+<h2 id="mental-model">Mental model</h2>
+<p>The body is not just trying to lose fat; it is trying to maintain safe blood glucose and energy. If food is unavailable or poorly timed, stress hormones become the bridge fuel. Deering's approach tries to make food, not stress hormones, the bridge.</p>
+      </div>
+    </article>
+
+    <section class="wiki-related">
+      <h2>Related pages</h2>
+      <ul><li><a href="../concepts/how-to-heal-your-metabolism.html">How to Heal Your Metabolism</a></li></ul>
+    </section>
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/concepts/building-products-users-love.html
+++ b/wiki/concepts/building-products-users-love.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Building Products Users Love · Jay Sosa Wiki</title>
+    <meta name="description" content="YC&#x27;s product doctrine is that a startup should first make something a small number of users love, not something a large number of users merely like. Until that is true, almost everything else is a distraction. Sam...">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/concepts/building-products-users-love.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-concept">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Concept</p>
+      <h1>Building Products Users Love</h1>
+      <p class="meta">Concept · Updated 2026-05-27 · Confidence: high</p>
+      <div class="wiki-tags"><span>product</span><span>strategy</span></div>
+      <div class="wiki-content">
+<p>YC's product doctrine is that a startup should first make something a small number of users love, not something a large number of users merely like. Until that is true, almost everything else is a distraction.</p>
+<h2 id="core-doctrine">Core doctrine</h2>
+<ul>
+<li>Build something users love; merely being liked is not enough.</li>
+<li>Start simple: a smaller surface area makes it possible to do one thing extremely well.</li>
+<li>Recruit early users manually rather than buying low-signal traffic.</li>
+<li>Keep the feedback loop tight: talk to users, watch them use the product, ship improvements, repeat.</li>
+<li>Founders should do sales and support themselves early; putting people between founders and users delays learning.</li>
+<li>Metrics should measure real usage and love: retention, active use, activity, revenue, NPS, and word of mouth — not vanity registrations.</li>
+</ul>
+<h2 id="product-quality-bar">Product quality bar</h2>
+<p>Sam Altman stresses fanaticism: founders should feel physical pain when the product is bad. This includes product details, onboarding, copy, customer support, and responsiveness. <a href="../entities/keith-rabois.html">Keith Rabois</a> echoes the same principle from an operator lens: details that seem internal or minor can shape the culture of excellence that eventually reaches users.</p>
+<h2 id="early-product-traps">Early product traps</h2>
+<ul>
+<li>Launching only after a long stealth build with too little feedback.</li>
+<li>Building for too many segments instead of one core user.</li>
+<li>Automating too early before understanding the manual process.</li>
+<li>Adding every requested feature rather than diagnosing the underlying user problem.</li>
+<li>Mistaking press or partnerships for product love.</li>
+</ul>
+<h2 id="kevin-hale-product-craft-addendum">Kevin Hale product craft addendum</h2>
+<p>Lecture 07 expands the product-love idea into craft: first impressions, microcopy, documentation, support, error states, and emotionally intelligent details all shape whether users feel the product cares about them. See <a href="../concepts/product-delight-and-craft.html">Product Delight and Craft</a>.</p>
+<h2 id="founder-80-20-addendum">Founder 80/20 addendum</h2>
+<p><a href="../concepts/founder-80-20-principle.html">Founder 80/20 Principle</a> echoes the product-love doctrine: product leverage sits in core features, aha moments, intuitive flows, and customer experience more than nice-to-haves, tutorials, aesthetic polish, or logo design.</p>
+      </div>
+    </article>
+
+    <section class="wiki-related">
+      <h2>Related pages</h2>
+      <ul><li><a href="../entities/keith-rabois.html">Keith Rabois</a></li>
+<li><a href="../concepts/product-delight-and-craft.html">Product Delight and Craft</a></li>
+<li><a href="../concepts/founder-80-20-principle.html">Founder 80/20 Principle</a></li>
+<li><a href="../concepts/startup-user-research.html">Startup User Research</a></li>
+<li><a href="../concepts/yc-how-to-start-a-startup.html">YC How to Start a Startup</a></li></ul>
+    </section>
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/concepts/contested-nutrition-claims-kate-deering.html
+++ b/wiki/concepts/contested-nutrition-claims-kate-deering.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Contested Nutrition Claims — Kate Deering · Jay Sosa Wiki</title>
+    <meta name="description" content="This page tracks claims from kate-deering&#x27;s How to Heal Your Metabolism that are useful to understand but should not be treated as settled medical or nutritional consensus. Treat the book as a hypothesis-generating...">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/concepts/contested-nutrition-claims-kate-deering.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-concept">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Concept</p>
+      <h1>Contested Nutrition Claims — Kate Deering</h1>
+      <p class="meta">Concept · Updated 2026-05-28 · Confidence: medium</p>
+      <div class="wiki-tags"><span>health</span><span>nutrition</span><span>metabolism</span><span>research</span></div>
+      <div class="wiki-content">
+<p>This page tracks claims from <a href="../entities/kate-deering.html">Kate Deering</a>'s <em>How to Heal Your Metabolism</em> that are useful to understand but should not be treated as settled medical or nutritional consensus.</p>
+<h2 id="claims-to-handle-cautiously">Claims to handle cautiously</h2>
+<ul>
+<li><strong>Health as high metabolism:</strong> useful lens, but reductionist if used alone.</li>
+<li><strong>Pulse/temperature targets:</strong> practical signals, not definitive diagnostics.</li>
+<li><strong>TSH scepticism:</strong> broader thyroid panels can matter, but TSH remains clinically useful.</li>
+<li><strong>“Adrenal fatigue”:</strong> contested framing; HPA-axis issues and adrenal insufficiency are distinct clinical concepts.</li>
+<li><strong>Saturated fat defence:</strong> evidence is context-dependent; ApoB/LDL, genetics, whole diet, and replacement nutrient matter.</li>
+<li><strong>Broad PUFA toxicity:</strong> conflicts with many mainstream recommendations favouring unsaturated fats.</li>
+<li><strong>Fruit juice/sugar as therapeutic:</strong> may not suit diabetes, insulin resistance, hypertriglyceridaemia, reflux, or dental risk.</li>
+<li><strong>Grain/legume/nut avoidance:</strong> many population studies associate whole grains, legumes, and nuts with benefits, though individual tolerance varies.</li>
+<li><strong>Raw milk:</strong> carries pathogen risk and is discouraged by public-health bodies for vulnerable groups.</li>
+<li><strong>High salt:</strong> may be harmful in salt-sensitive hypertension, kidney disease, heart failure, and some cardiovascular contexts.</li>
+<li><strong>Eggshell calcium:</strong> dosing, sanitation, kidney-stone risk, and total calcium intake matter.</li>
+<li><strong>Exercise reduction:</strong> overtraining is real, but intense exercise is not inherently anti-metabolic for everyone.</li>
+</ul>
+<h2 id="how-to-use-the-framework-safely">How to use the framework safely</h2>
+<p>Treat the book as a hypothesis-generating model. Its strongest use is self-observation: energy, warmth, sleep, digestion, mood, appetite, training tolerance, and food tolerance. Its weakest use would be replacing medical evaluation for thyroid disease, diabetes, cardiovascular risk, kidney disease, eating disorders, pregnancy, or major symptoms.</p>
+      </div>
+    </article>
+
+    <section class="wiki-related">
+      <h2>Related pages</h2>
+      <ul><li><a href="../entities/kate-deering.html">Kate Deering</a></li>
+<li><a href="../concepts/how-to-heal-your-metabolism.html">How to Heal Your Metabolism</a></li></ul>
+    </section>
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/concepts/conviction-consequence-delegation.html
+++ b/wiki/concepts/conviction-consequence-delegation.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Conviction-Consequence Delegation · Jay Sosa Wiki</title>
+    <meta name="description" content="The conviction-consequence framework, attributed in the source to lessons keith-rabois learned from peter-thiel, is a delegation model for deciding when a leader should let someone else decide and when they must...">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/concepts/conviction-consequence-delegation.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-concept">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Concept</p>
+      <h1>Conviction-Consequence Delegation</h1>
+      <p class="meta">Concept · Updated 2026-05-28 · Confidence: medium</p>
+      <div class="wiki-tags"><span>operator</span><span>strategy</span><span>company</span></div>
+      <div class="wiki-content">
+<p>The conviction-consequence framework, attributed in the source to lessons <a href="../entities/keith-rabois.html">Keith Rabois</a> learned from <a href="../entities/peter-thiel.html">Peter Thiel</a>, is a delegation model for deciding when a leader should let someone else decide and when they must intervene.</p>
+<h2 id="the-two-axes">The two axes</h2>
+<ul>
+<li><strong>Consequence:</strong> how much damage or upside the decision can create.</li>
+<li><strong>Conviction:</strong> how strongly the leader believes they know the right answer.</li>
+</ul>
+<h2 id="how-to-apply-it">How to apply it</h2>
+<ul>
+<li><strong>Low consequence + low conviction:</strong> delegate completely; mistakes are learning opportunities.</li>
+<li><strong>Low consequence + high conviction:</strong> usually delegate, but explain the pattern if the lesson is valuable.</li>
+<li><strong>High consequence + low conviction:</strong> involve the right experts and avoid pretending certainty.</li>
+<li><strong>High consequence + high conviction:</strong> do not abdicate. Intervene, explain the reasoning, and teach the decision model.</li>
+</ul>
+<h2 id="synthesis">Synthesis</h2>
+<p>The point is not to micromanage. It is to match decision rights to risk, certainty, and learning value. This connects to <a href="../concepts/startup-operating-and-management.html">Startup Operating and Management</a>: delegation without abdication means giving people room where failure is survivable while preserving founder judgement on decisions that can seriously damage the company.</p>
+      </div>
+    </article>
+
+    <section class="wiki-related">
+      <h2>Related pages</h2>
+      <ul><li><a href="../entities/keith-rabois.html">Keith Rabois</a></li>
+<li><a href="../entities/peter-thiel.html">Peter Thiel</a></li>
+<li><a href="../concepts/startup-operating-and-management.html">Startup Operating and Management</a></li>
+<li><a href="../concepts/keith-rabois-operating-frameworks.html">Keith Rabois Operating Frameworks</a></li></ul>
+    </section>
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/concepts/doing-things-that-do-not-scale.html
+++ b/wiki/concepts/doing-things-that-do-not-scale.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Doing Things That Do Not Scale · Jay Sosa Wiki</title>
+    <meta name="description" content="Doing things that do not scale means deliberately using manual, high-touch, or messy actions early because they create learning, quality, and momentum before automation is justified. Stanley Tang describes the early...">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/concepts/doing-things-that-do-not-scale.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-concept">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Concept</p>
+      <h1>Doing Things That Do Not Scale</h1>
+      <p class="meta">Concept · Updated 2026-05-27 · Confidence: high</p>
+      <div class="wiki-tags"><span>operator</span><span>product</span><span>gtm</span><span>strategy</span></div>
+      <div class="wiki-content">
+<p>Doing things that do not scale means deliberately using manual, high-touch, or messy actions early because they create learning, quality, and momentum before automation is justified.</p>
+<h2 id="doordash-example">DoorDash example</h2>
+<p>Stanley Tang describes the early DoorDash experiment: a simple landing page with PDF menus, founders taking phone orders, founders doing deliveries, and direct conversations with restaurants and customers. The point was not operational elegance; it was testing whether demand existed.</p>
+<h2 id="why-it-works">Why it works</h2>
+<ul>
+<li>It turns a startup idea into an experiment.</li>
+<li>It creates direct learning about customer pain and operational constraints.</li>
+<li>It lets the team launch before infrastructure exists.</li>
+<li>It builds early user love through founder effort.</li>
+<li>It avoids spending months automating the wrong workflow.</li>
+</ul>
+<h2 id="pr-and-getting-started">PR and getting started</h2>
+<p>The same lecture set frames PR and initial traction as founder-led work, not something to delegate too early. Early founders should create their own momentum and stories before expecting scalable channels to work.</p>
+      </div>
+    </article>
+
+    <section class="wiki-related">
+      <h2>Related pages</h2>
+      <ul><li><a href="../concepts/startup-user-research.html">Startup User Research</a></li></ul>
+    </section>
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/concepts/eleven-star-experience.html
+++ b/wiki/concepts/eleven-star-experience.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Eleven-Star Experience · Jay Sosa Wiki</title>
+    <meta name="description" content="Brian Chesky&#x27;s eleven-star exercise is a product imagination tool. Instead of asking what a normal five-star experience looks like, the team pushes the experience into absurd six-, seven-, eight-, nine-, and ten-star...">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/concepts/eleven-star-experience.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-concept">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Concept</p>
+      <h1>Eleven-Star Experience</h1>
+      <p class="meta">Concept · Updated 2026-05-28 · Confidence: medium</p>
+      <div class="wiki-tags"><span>product</span><span>strategy</span><span>operator</span></div>
+      <div class="wiki-content">
+<p>Brian Chesky's eleven-star exercise is a product imagination tool. Instead of asking what a normal five-star experience looks like, the team pushes the experience into absurd six-, seven-, eight-, nine-, and ten-star versions, then works backwards to a version that can actually be built.</p>
+<h2 id="the-mechanism">The mechanism</h2>
+<p>A five-star Airbnb check-in means nothing went wrong: the host greeted the guest or the door code worked. A six-star check-in might include a favourite bottle of wine, fruit, snacks, and a handwritten card. A seven-star version might include airport pickup, a surfboard for a guest who loves surfing, and a local tour. Higher stars become deliberately absurd: a parade, screaming fans, or Elon Musk taking the guest to space.</p>
+<p>The point is not to build the ten-star version. It is to stretch the team's imagination so that a six- or seven-star experience suddenly feels practical. That gap between five-star reliability and six-star delight can become the differentiated product.</p>
+<h2 id="why-it-works">Why it works</h2>
+<p>The exercise forces empathy and specificity. It asks what would make one customer feel genuinely seen, rather than what average feature would satisfy a segment. It also separates product-market-fit discovery from later industrialisation: first prove that a tiny group loves the experience, then scale the repeatable parts.</p>
+      </div>
+    </article>
+
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/concepts/enterprise-software-startups.html
+++ b/wiki/concepts/enterprise-software-startups.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Enterprise Software Startups · Jay Sosa Wiki</title>
+    <meta name="description" content="Enterprise software startups exploit technology and business-model discontinuities in how organisations work. Aaron Levie&#x27;s Box lecture argues that enterprise software became attractive because cloud, mobile, cheaper...">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/concepts/enterprise-software-startups.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-concept">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Concept</p>
+      <h1>Enterprise Software Startups</h1>
+      <p class="meta">Concept · Updated 2026-05-28 · Confidence: high</p>
+      <div class="wiki-tags"><span>company</span><span>product</span><span>market</span><span>strategy</span><span>gtm</span></div>
+      <div class="wiki-content">
+<p>Enterprise software startups exploit technology and business-model discontinuities in how organisations work. Aaron Levie's Box lecture argues that enterprise software became attractive because cloud, mobile, cheaper storage, faster browsers, and user-led adoption changed the rules.</p>
+<h2 id="why-enterprise-became-startup-friendly">Why enterprise became startup-friendly</h2>
+<ul>
+<li>Cloud computing reduced the need for on-prem deployment and made adoption faster.</li>
+<li>Mobile devices forced companies to support work anywhere, not only on managed office networks.</li>
+<li>Users began bringing tools into organisations, giving startups a bottom-up entry point.</li>
+<li>Standardised SaaS products replaced expensive customised deployments.</li>
+<li>Every industry began needing technology competence because customer expectations changed.</li>
+</ul>
+<h2 id="patterns-for-finding-opportunities">Patterns for finding opportunities</h2>
+<ol>
+<li><strong>Spot technology disruptions:</strong> find a wide gap between how work is done and what new technology makes possible.</li>
+<li><strong>Start intentionally small:</strong> use a wedge that incumbents dismiss but customers feel urgently.</li>
+<li><strong>Find asymmetries:</strong> do what incumbents cannot or will not do because of business-model, architecture, or channel constraints.</li>
+<li><strong>Find future-working customers:</strong> bleeding-edge customers reveal missing software for how the market will work later.</li>
+<li><strong>Listen, but do not blindly build requests:</strong> translate customer problems into simple products.</li>
+<li><strong>Modularise, do not customise:</strong> build platforms and APIs rather than bespoke software for every customer.</li>
+<li><strong>Use consumer-grade UX:</strong> product-led adoption should complement, not replace, enterprise sales.</li>
+</ol>
+<h2 id="software-moats-addendum">Software moats addendum</h2>
+<p><a href="../concepts/software-moats.html">Software Moats</a> is especially relevant to enterprise software because deep workflow integration, ecosystem lock-in, channel control, regulatory requirements, and proprietary operational data can make a B2B product far harder to replace than its visible feature set suggests.</p>
+<h2 id="ai-native-business-model-addendum">AI-native business model addendum</h2>
+<p><a href="../entities/gokul-rajaram.html">Gokul Rajaram</a> argues that AI-native enterprise companies must avoid being thin systems of action on top of incumbents. Durable entrants may need proprietary data loops, deep workflow ownership, migration tooling, outcome-based pricing, and sometimes the ambition to replace the system of record. See <a href="../concepts/ai-native-software-business-models.html">AI-native Software Business Models</a>.</p>
+      </div>
+    </article>
+
+    <section class="wiki-related">
+      <h2>Related pages</h2>
+      <ul><li><a href="../concepts/software-moats.html">Software Moats</a></li>
+<li><a href="../entities/gokul-rajaram.html">Gokul Rajaram</a></li>
+<li><a href="../concepts/ai-native-software-business-models.html">AI-native Software Business Models</a></li>
+<li><a href="../concepts/startup-ideas-and-markets.html">Startup Ideas and Markets</a></li>
+<li><a href="../concepts/yc-how-to-start-a-startup.html">YC How to Start a Startup</a></li></ul>
+    </section>
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/concepts/founder-80-20-principle.html
+++ b/wiki/concepts/founder-80-20-principle.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Founder 80/20 Principle · Jay Sosa Wiki</title>
+    <meta name="description" content="Greg Isenberg&#x27;s 20 Oct 2024 tweet applies the Pareto/80-20 heuristic to founder work: in each domain, the founder should identify the minority of effort that drives most of the outcome and avoid over-investing in...">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/concepts/founder-80-20-principle.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-concept">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Concept</p>
+      <h1>Founder 80/20 Principle</h1>
+      <p class="meta">Concept · Updated 2026-05-27 · Confidence: medium</p>
+      <div class="wiki-tags"><span>strategy</span><span>operator</span><span>product</span><span>gtm</span></div>
+      <div class="wiki-content">
+<p>Greg Isenberg's 20 Oct 2024 tweet applies the Pareto/80-20 heuristic to founder work: in each domain, the founder should identify the minority of effort that drives most of the outcome and avoid over-investing in lower-leverage surface area.</p>
+<h2 id="core-pattern">Core pattern</h2>
+<p>The tweet's repeated claim is that founder leverage usually sits closer to market pull, distribution, retention, customer experience, and execution than to polish, abstract strategy, or company-led theatre.</p>
+<h2 id="80-20-map">80/20 map</h2>
+<ul>
+<li><strong>Traction:</strong> distribution over product polish.</li>
+<li><strong>Growth:</strong> retention over acquisition.</li>
+<li><strong>Revenue:</strong> existing customers over new leads.</li>
+<li><strong>Pricing experiments:</strong> positioning tweaks over literal price changes.</li>
+<li><strong>Brand:</strong> customer experience over logo design.</li>
+<li><strong>Sales:</strong> listening over pitching.</li>
+<li><strong>Community:</strong> empowering users over company-led initiatives.</li>
+<li><strong>Product:</strong> core features over nice-to-haves.</li>
+<li><strong>Time:</strong> executing over strategising.</li>
+<li><strong>Insights:</strong> user feedback over behavioural analytics alone.</li>
+<li><strong>Pricing:</strong> value perception over actual costs.</li>
+<li><strong>Marketing:</strong> word-of-mouth over paid ads.</li>
+<li><strong>Onboarding:</strong> aha moments over feature tutorials.</li>
+<li><strong>UI/UX:</strong> intuitive flow over aesthetics.</li>
+<li><strong>Viral growth:</strong> reducing friction over incentivising sharing.</li>
+<li><strong>Roadmap:</strong> market pull over vision push.</li>
+<li><strong>Team management:</strong> context setting over direct orders.</li>
+<li><strong>Customer interviews:</strong> observing over asking.</li>
+<li><strong>Market positioning:</strong> owning a niche over broad appeal.</li>
+<li><strong>Founder time:</strong> working on the business over staying trapped in the business.</li>
+</ul>
+<h2 id="synthesis">Synthesis</h2>
+<p>This is a compact founder operating checklist. It overlaps strongly with <a href="../concepts/startup-growth.html">Startup Growth</a> on retention, <a href="../concepts/startup-sales-and-marketing.html">Startup Sales and Marketing</a> on listening and qualification, <a href="../concepts/building-products-users-love.html">Building Products Users Love</a> on core experience, <a href="../concepts/startup-user-research.html">Startup User Research</a> on observation, <a href="../concepts/monopoly-theory.html">Monopoly Theory</a> on owning a niche, and <a href="../concepts/startup-execution-and-operating-rhythm.html">Startup Execution and Operating Rhythm</a> on execution over excessive planning.</p>
+      </div>
+    </article>
+
+    <section class="wiki-related">
+      <h2>Related pages</h2>
+      <ul><li><a href="../concepts/startup-growth.html">Startup Growth</a></li>
+<li><a href="../concepts/startup-sales-and-marketing.html">Startup Sales and Marketing</a></li>
+<li><a href="../concepts/building-products-users-love.html">Building Products Users Love</a></li>
+<li><a href="../concepts/startup-user-research.html">Startup User Research</a></li>
+<li><a href="../concepts/monopoly-theory.html">Monopoly Theory</a></li>
+<li><a href="../concepts/startup-execution-and-operating-rhythm.html">Startup Execution and Operating Rhythm</a></li></ul>
+    </section>
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/concepts/founder-psychology-and-fit.html
+++ b/wiki/concepts/founder-psychology-and-fit.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Founder Psychology and Fit · Jay Sosa Wiki</title>
+    <meta name="description" content="Founder fit is the alignment between a founder, a problem, and the long psychological commitment needed to build a company. The YC lectures repeatedly warn that startups are harder, longer, and less glamorous than...">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/concepts/founder-psychology-and-fit.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-concept">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Concept</p>
+      <h1>Founder Psychology and Fit</h1>
+      <p class="meta">Concept · Updated 2026-05-27 · Confidence: high</p>
+      <div class="wiki-tags"><span>operator</span><span>strategy</span><span>person</span></div>
+      <div class="wiki-content">
+<p>Founder fit is the alignment between a founder, a problem, and the long psychological commitment needed to build a company. The YC lectures repeatedly warn that startups are harder, longer, and less glamorous than outsiders expect.</p>
+<h2 id="reasons-to-start">Reasons to start</h2>
+<p>Dustin Moskovitz's preferred reason is that the founder “can't not do it”: the idea is beating itself out of them, the world needs it, and they are well-suited to solve it. Glamour, being the boss, flexibility, and assumed wealth are weak reasons.</p>
+<h2 id="ceo-psychology">CEO psychology</h2>
+<p>Founders carry responsibility for employees, customers, investors, and the opportunity cost of everyone involved. They are always on call and often face widening emotional swings as the company grows. Sam Altman and Moskovitz both stress that managing one's own psychology is a core CEO responsibility.</p>
+<h2 id="founder-judgement">Founder judgement</h2>
+<p><a href="../entities/reid-hoffman.html">Reid Hoffman</a> argues that great founders are not superhuman generalists; they have a few superpowers and navigate paradoxes: belief and fear, persistence and flexibility, internal focus and external network-building, long-term vision and short-term problem-solving. The test is whether the founder can learn, adapt, and assemble networks while crossing uncertain ground.</p>
+      </div>
+    </article>
+
+    <section class="wiki-related">
+      <h2>Related pages</h2>
+      <ul><li><a href="../entities/reid-hoffman.html">Reid Hoffman</a></li>
+<li><a href="../concepts/yc-how-to-start-a-startup.html">YC How to Start a Startup</a></li></ul>
+    </section>
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/concepts/fragmented-industry-vertical-integration.html
+++ b/wiki/concepts/fragmented-industry-vertical-integration.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Fragmented Industry Vertical Integration · Jay Sosa Wiki</title>
+    <meta name="description" content="The source summarises a Rabois startup-success formula: find a large, highly fragmented industry with low NPS, then vertically integrate a simpler product or experience. The opportunity is strongest when: A...">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/concepts/fragmented-industry-vertical-integration.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-concept">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Concept</p>
+      <h1>Fragmented Industry Vertical Integration</h1>
+      <p class="meta">Concept · Updated 2026-05-28 · Confidence: medium</p>
+      <div class="wiki-tags"><span>strategy</span><span>market</span><span>company</span><span>gtm</span></div>
+      <div class="wiki-content">
+<p>The source summarises a Rabois startup-success formula: find a large, highly fragmented industry with low NPS, then vertically integrate a simpler product or experience.</p>
+<h2 id="pattern">Pattern</h2>
+<p>The opportunity is strongest when:</p>
+<ul>
+<li>the market is large;</li>
+<li>incumbents are fragmented rather than dominated by one excellent operator;</li>
+<li>customer experience is poor or disliked;</li>
+<li>the product/service can be simplified by owning more of the value chain;</li>
+<li>technology, operations, or distribution can create a new integrated experience.</li>
+</ul>
+<h2 id="why-vertical-integration-matters">Why vertical integration matters</h2>
+<p>A fragmented low-NPS market often has broken handoffs, inconsistent quality, and no single accountable owner of the customer experience. Vertical integration can turn that mess into a coherent product — but it also increases operational burden, so it requires strong execution and <a href="../concepts/startup-operating-and-management.html">Startup Operating and Management</a>.</p>
+<h2 id="relationship-to-other-frameworks">Relationship to other frameworks</h2>
+<p>This complements <a href="../concepts/software-moats.html">Software Moats</a> and <a href="../concepts/monopoly-theory.html">Monopoly Theory</a>. The initial wedge is not enough; the company should compound into defensibility through integration, data, distribution, brand, network effects, or scale.</p>
+      </div>
+    </article>
+
+    <section class="wiki-related">
+      <h2>Related pages</h2>
+      <ul><li><a href="../concepts/startup-operating-and-management.html">Startup Operating and Management</a></li>
+<li><a href="../concepts/software-moats.html">Software Moats</a></li>
+<li><a href="../concepts/monopoly-theory.html">Monopoly Theory</a></li>
+<li><a href="../concepts/keith-rabois-operating-frameworks.html">Keith Rabois Operating Frameworks</a></li>
+<li><a href="../concepts/startup-ideas-and-markets.html">Startup Ideas and Markets</a></li>
+<li><a href="../entities/keith-rabois.html">Keith Rabois</a></li></ul>
+    </section>
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/concepts/hardware-product-development.html
+++ b/wiki/concepts/hardware-product-development.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Hardware Product Development · Jay Sosa Wiki</title>
+    <meta name="description" content="Hosain Rahman&#x27;s lecture frames hardware product development as full-stack product building: hardware, software, data, design, supply chain, brand, retail, and user experience must work together. Hardware products are...">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/concepts/hardware-product-development.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-concept">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Concept</p>
+      <h1>Hardware Product Development</h1>
+      <p class="meta">Concept · Updated 2026-05-27 · Confidence: high</p>
+      <div class="wiki-tags"><span>product</span><span>strategy</span><span>company</span></div>
+      <div class="wiki-content">
+<p>Hosain Rahman's lecture frames hardware product development as full-stack product building: hardware, software, data, design, supply chain, brand, retail, and user experience must work together.</p>
+<h2 id="full-stack-challenge">Full-stack challenge</h2>
+<p>Hardware products are systems, not isolated devices. A strong product has to integrate mechanical engineering, electrical engineering, software, industrial design, manufacturing, data processing, packaging, support, and business model.</p>
+<h2 id="product-development-phases">Product development phases</h2>
+<p>The Jawbone process described in the lecture moves through exploration, validation, concept, and development. Early phases are creative and demo-driven; later phases require product management, engineering, supply-chain discipline, retail planning, and launch readiness.</p>
+<h2 id="distinctive-hardware-risks">Distinctive hardware risks</h2>
+<ul>
+<li>Iteration loops are slower and more expensive than software.</li>
+<li>Quality failures become physical and operational, not just bugs.</li>
+<li>Manufacturing and supply-chain constraints shape product decisions.</li>
+<li>The product has to be useful, beautiful, and reliable in the real world.</li>
+</ul>
+      </div>
+    </article>
+
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/concepts/how-to-heal-your-metabolism.html
+++ b/wiki/concepts/how-to-heal-your-metabolism.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>How to Heal Your Metabolism · Jay Sosa Wiki</title>
+    <meta name="description" content="How to Heal Your Metabolism by kate-deering is a book-length, Ray Peat/Broda Barnes-influenced nutrition framework. Its central claim is that health is largely a function of cellular energy production: a robust...">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/concepts/how-to-heal-your-metabolism.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-concept">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Concept</p>
+      <h1>How to Heal Your Metabolism</h1>
+      <p class="meta">Concept · Updated 2026-05-28 · Confidence: medium</p>
+      <div class="wiki-tags"><span>health</span><span>nutrition</span><span>metabolism</span><span>research</span></div>
+      <div class="wiki-content">
+<p><em>How to Heal Your Metabolism</em> by <a href="../entities/kate-deering.html">Kate Deering</a> is a book-length, Ray Peat/Broda Barnes-influenced nutrition framework. Its central claim is that health is largely a function of cellular energy production: a robust metabolism supports warmth, digestion, sleep, mood, libido, fertility, immunity, and stable body composition.</p>
+<h2 id="book-level-thesis">Book-level thesis</h2>
+<p>The book argues that many modern health practices suppress metabolism rather than restore it: chronic low-calorie dieting, low-carb dieting, over-exercising, excess plain water, processed foods, vegetable/seed oils, soy, grains, legumes, nuts, poor sleep, and chronic emotional stress. Deering's alternative is a “pro-metabolic” diet and lifestyle built around digestible carbohydrates, high-quality proteins, saturated fats, minerals, sleep, appropriate movement, and stress reduction.</p>
+<h2 id="chapter-map">Chapter map</h2>
+<ul>
+<li>Chapters 1–5 establish the model: health as metabolism, thyroid as conductor, saturated fat defence, PUFA critique, sugar/carbohydrate defence, and grain/gluten avoidance.</li>
+<li>Chapters 6–10 cover food quality: vegetables, protein, “super proteins”, dairy/milk, and muscle meats.</li>
+<li>Chapters 11–15 cover nuts/seeds, legumes/soy, protein powders, salt/coffee/eggshell calcium, and blood sugar balancing.</li>
+<li>Chapters 16–20 add lifestyle and implementation: sleep, exercise, hydration, happiness, sample meals, FAQ, and recipes.</li>
+<li>Appendices AA–AD give practical food lists: optimal carbohydrates, best proteins, best fats, and PUFA oils to avoid.</li>
+</ul>
+<h2 id="core-concepts-extracted">Core concepts extracted</h2>
+<ul>
+<li><a href="../concepts/metabolism-as-a-health-model.html">Metabolism as a Health Model</a> — health inferred through warmth, pulse, digestion, sleep, mood, libido, and resilience.</li>
+<li><a href="../concepts/thyroid-stress-hormones-and-energy-regulation.html">Thyroid, Stress Hormones, and Energy Regulation</a> — thyroid as the primary energy system; adrenaline/cortisol as compensatory emergency systems.</li>
+<li><a href="../concepts/pro-metabolic-nutrition.html">Pro-Metabolic Nutrition</a> — digestible carbohydrates, dairy, gelatin/broth, shellfish, liver, eggs, saturated fats, salt, and food quality.</li>
+<li><a href="../concepts/pufa-avoidance.html">PUFA Avoidance</a> — seed oils, nuts, soy, fatty fish oil, and high-PUFA animal fats as anti-metabolic in Deering's model.</li>
+<li><a href="../concepts/blood-sugar-balancing-for-metabolic-health.html">Blood Sugar Balancing for Metabolic Health</a> — meal timing, carb/protein/fat pairing, liver glycogen, and stress hormone avoidance.</li>
+<li><a href="../concepts/protein-quality-and-amino-acid-balance.html">Protein Quality and Amino Acid Balance</a> — favour dairy, eggs, liver, shellfish, white fish, potato protein, gelatin, and broth over heavy muscle-meat reliance.</li>
+<li><a href="../concepts/metabolic-lifestyle-recovery.html">Metabolic Lifestyle Recovery</a> — sleep, exercise dose, hydration/electrolytes, stress, happiness, and community as metabolic inputs.</li>
+<li><a href="../concepts/contested-nutrition-claims-kate-deering.html">Contested Nutrition Claims — Kate Deering</a> — claims requiring caution or mainstream comparison.</li>
+</ul>
+<h2 id="practical-synthesis">Practical synthesis</h2>
+<p>The book is most useful as a coherent recovery framework for people who suspect they have been chronically under-fuelled, over-trained, low-carb dieting, or living on stress hormones. Its practical edge is not a single food list but a feedback loop: add digestible fuel and minerals, reduce hard-to-recover stressors, then watch temperature, pulse, sleep, bowel movements, energy, mood, hunger, and digestion.</p>
+      </div>
+    </article>
+
+    <section class="wiki-related">
+      <h2>Related pages</h2>
+      <ul><li><a href="../entities/kate-deering.html">Kate Deering</a></li>
+<li><a href="../concepts/metabolism-as-a-health-model.html">Metabolism as a Health Model</a></li>
+<li><a href="../concepts/thyroid-stress-hormones-and-energy-regulation.html">Thyroid, Stress Hormones, and Energy Regulation</a></li>
+<li><a href="../concepts/pro-metabolic-nutrition.html">Pro-Metabolic Nutrition</a></li>
+<li><a href="../concepts/pufa-avoidance.html">PUFA Avoidance</a></li>
+<li><a href="../concepts/blood-sugar-balancing-for-metabolic-health.html">Blood Sugar Balancing for Metabolic Health</a></li>
+<li><a href="../concepts/protein-quality-and-amino-acid-balance.html">Protein Quality and Amino Acid Balance</a></li>
+<li><a href="../concepts/metabolic-lifestyle-recovery.html">Metabolic Lifestyle Recovery</a></li>
+<li><a href="../concepts/contested-nutrition-claims-kate-deering.html">Contested Nutrition Claims — Kate Deering</a></li></ul>
+    </section>
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/concepts/index.html
+++ b/wiki/concepts/index.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Concepts · Jay Sosa Wiki</title>
+    <meta name="description" content="Durable ideas, mental models, methods, technologies, product and market themes from Jay&#x27;s public wiki.">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-listing">
+    <header>
+      <h1>Concepts</h1>
+      <p class="subtitle">44 pages</p>
+      <hr class="header-rule">
+    </header>
+    <section>
+      <h2>About</h2>
+      <p>Durable ideas, mental models, methods, technologies, product and market themes from Jay&#x27;s public wiki.</p>
+      <p><a class="view-all" href="index.html">Wiki index</a></p>
+    </section>
+    <section>
+      <h2>Pages</h2>
+      <div class="wiki-card-list">
+        <a class="wiki-card" href="../concepts/agent-maintained-knowledge-base.html">
+          <span class="wiki-card-title">Agent-Maintained Knowledge Base</span>
+          <span class="wiki-card-description">An agent-maintained knowledge base is a repository where the LLM is responsible for the repetitive maintenance work: summarising, filing, cross-linking, updating pages, flagging contradictions, and keeping...</span>
+        </a>
+        <a class="wiki-card" href="../concepts/ai-founder-mode.html">
+          <span class="wiki-card-title">AI Founder Mode</span>
+          <span class="wiki-card-description">Brian Chesky describes founder mode as the founder/CEO staying close enough to the work to steer the company, rather than over-delegating to professional managers and being managed by the organisation. AI founder...</span>
+        </a>
+        <a class="wiki-card" href="../concepts/ai-era-product-management.html">
+          <span class="wiki-card-title">AI-era Product Management</span>
+          <span class="wiki-card-description">Gokul Rajaram argues that AI changes product management because software is becoming faster, cheaper, and less deterministic to build. The durable human role is judgement: choosing what matters, defining the customer...</span>
+        </a>
+        <a class="wiki-card" href="../concepts/ai-native-software-business-models.html">
+          <span class="wiki-card-title">AI-native Software Business Models</span>
+          <span class="wiki-card-description">Gokul Rajaram&#x27;s AI-software thesis is that thin AI features are fragile, but AI-native companies can be durable when they own scarce assets, deep workflows, systems of record, data loops, regulated control points,...</span>
+        </a>
+        <a class="wiki-card" href="../concepts/barrels-and-ammunition.html">
+          <span class="wiki-card-title">Barrels and Ammunition</span>
+          <span class="wiki-card-description">Barrels and ammunition is keith-rabois&#x27;s hiring and team-design metaphor. A barrel can take an idea, aim it, assemble the people needed, and ship the outcome. Ammunition is high-quality talent that needs a barrel to...</span>
+        </a>
+        <a class="wiki-card" href="../concepts/blood-sugar-balancing-for-metabolic-health.html">
+          <span class="wiki-card-title">Blood Sugar Balancing for Metabolic Health</span>
+          <span class="wiki-card-description">Deering argues that metabolic healing depends on stable fuel availability. Low blood sugar triggers adrenaline, cortisol, and glucagon; excessive spikes trigger insulin and storage. The goal is a steady, warm, calm...</span>
+        </a>
+        <a class="wiki-card" href="../concepts/building-products-users-love.html">
+          <span class="wiki-card-title">Building Products Users Love</span>
+          <span class="wiki-card-description">YC&#x27;s product doctrine is that a startup should first make something a small number of users love, not something a large number of users merely like. Until that is true, almost everything else is a distraction. Sam...</span>
+        </a>
+        <a class="wiki-card" href="../concepts/contested-nutrition-claims-kate-deering.html">
+          <span class="wiki-card-title">Contested Nutrition Claims — Kate Deering</span>
+          <span class="wiki-card-description">This page tracks claims from kate-deering&#x27;s How to Heal Your Metabolism that are useful to understand but should not be treated as settled medical or nutritional consensus. Treat the book as a hypothesis-generating...</span>
+        </a>
+        <a class="wiki-card" href="../concepts/conviction-consequence-delegation.html">
+          <span class="wiki-card-title">Conviction-Consequence Delegation</span>
+          <span class="wiki-card-description">The conviction-consequence framework, attributed in the source to lessons keith-rabois learned from peter-thiel, is a delegation model for deciding when a leader should let someone else decide and when they must...</span>
+        </a>
+        <a class="wiki-card" href="../concepts/doing-things-that-do-not-scale.html">
+          <span class="wiki-card-title">Doing Things That Do Not Scale</span>
+          <span class="wiki-card-description">Doing things that do not scale means deliberately using manual, high-touch, or messy actions early because they create learning, quality, and momentum before automation is justified. Stanley Tang describes the early...</span>
+        </a>
+        <a class="wiki-card" href="../concepts/eleven-star-experience.html">
+          <span class="wiki-card-title">Eleven-Star Experience</span>
+          <span class="wiki-card-description">Brian Chesky&#x27;s eleven-star exercise is a product imagination tool. Instead of asking what a normal five-star experience looks like, the team pushes the experience into absurd six-, seven-, eight-, nine-, and ten-star...</span>
+        </a>
+        <a class="wiki-card" href="../concepts/enterprise-software-startups.html">
+          <span class="wiki-card-title">Enterprise Software Startups</span>
+          <span class="wiki-card-description">Enterprise software startups exploit technology and business-model discontinuities in how organisations work. Aaron Levie&#x27;s Box lecture argues that enterprise software became attractive because cloud, mobile, cheaper...</span>
+        </a>
+        <a class="wiki-card" href="../concepts/founder-80-20-principle.html">
+          <span class="wiki-card-title">Founder 80/20 Principle</span>
+          <span class="wiki-card-description">Greg Isenberg&#x27;s 20 Oct 2024 tweet applies the Pareto/80-20 heuristic to founder work: in each domain, the founder should identify the minority of effort that drives most of the outcome and avoid over-investing in...</span>
+        </a>
+        <a class="wiki-card" href="../concepts/founder-psychology-and-fit.html">
+          <span class="wiki-card-title">Founder Psychology and Fit</span>
+          <span class="wiki-card-description">Founder fit is the alignment between a founder, a problem, and the long psychological commitment needed to build a company. The YC lectures repeatedly warn that startups are harder, longer, and less glamorous than...</span>
+        </a>
+        <a class="wiki-card" href="../concepts/fragmented-industry-vertical-integration.html">
+          <span class="wiki-card-title">Fragmented Industry Vertical Integration</span>
+          <span class="wiki-card-description">The source summarises a Rabois startup-success formula: find a large, highly fragmented industry with low NPS, then vertically integrate a simpler product or experience. The opportunity is strongest when: A...</span>
+        </a>
+        <a class="wiki-card" href="../concepts/hardware-product-development.html">
+          <span class="wiki-card-title">Hardware Product Development</span>
+          <span class="wiki-card-description">Hosain Rahman&#x27;s lecture frames hardware product development as full-stack product building: hardware, software, data, design, supply chain, brand, retail, and user experience must work together. Hardware products are...</span>
+        </a>
+        <a class="wiki-card" href="../concepts/how-to-heal-your-metabolism.html">
+          <span class="wiki-card-title">How to Heal Your Metabolism</span>
+          <span class="wiki-card-description">How to Heal Your Metabolism by kate-deering is a book-length, Ray Peat/Broda Barnes-influenced nutrition framework. Its central claim is that health is largely a function of cellular energy production: a robust...</span>
+        </a>
+        <a class="wiki-card" href="../concepts/jay-personal-knowledge-os.html">
+          <span class="wiki-card-title">Jay Personal Knowledge OS</span>
+          <span class="wiki-card-description">Jay&#x27;s Personal Knowledge OS is the local implementation of the llm-wiki pattern: a Hermes-maintained, Obsidian-compatible wiki for durable research and synthesis. Jay curates sources and asks questions. Hermes...</span>
+        </a>
+        <a class="wiki-card" href="../concepts/keith-rabois-operating-frameworks.html">
+          <span class="wiki-card-title">Keith Rabois Operating Frameworks</span>
+          <span class="wiki-card-description">This page synthesises a user-provided deep research report on keith-rabois&#x27;s public educational frameworks across lectures, interviews, newsletters, and startup advice. The source frames Rabois&#x27;s operating philosophy...</span>
+        </a>
+        <a class="wiki-card" href="../concepts/later-stage-startup-scaling.html">
+          <span class="wiki-card-title">Later-stage Startup Scaling</span>
+          <span class="wiki-card-description">Later-stage scaling begins after product-market fit, often around months 12–24. Sam Altman&#x27;s main transition is that the founder&#x27;s job shifts from building a great product to building a great company. A flat...</span>
+        </a>
+        <a class="wiki-card" href="../concepts/llm-wiki.html">
+          <span class="wiki-card-title">LLM Wiki</span>
+          <span class="wiki-card-description">An LLM Wiki is a persistent, agent-maintained markdown knowledge base where an LLM incrementally compiles sources into structured, cross-linked pages. The key distinction from ordinary retrieval is that knowledge is...</span>
+        </a>
+        <a class="wiki-card" href="../concepts/metabolic-lifestyle-recovery.html">
+          <span class="wiki-card-title">Metabolic Lifestyle Recovery</span>
+          <span class="wiki-card-description">Deering argues that food is necessary but not sufficient. Sleep, exercise dose, hydration, work stress, relationships, emotional state, and community all affect metabolic recovery. Good nutrition is a “bulletproof...</span>
+        </a>
+        <a class="wiki-card" href="../concepts/metabolism-as-a-health-model.html">
+          <span class="wiki-card-title">Metabolism as a Health Model</span>
+          <span class="wiki-card-description">In kate-deering&#x27;s How to Heal Your Metabolism, health is defined less as weight, lab normality, or visible fitness and more as a high cellular energy state. A well-functioning metabolism should produce warmth, good...</span>
+        </a>
+        <a class="wiki-card" href="../concepts/monopoly-theory.html">
+          <span class="wiki-card-title">Monopoly Theory</span>
+          <span class="wiki-card-description">Peter Thiel&#x27;s lecture argues that valuable companies both create value and capture part of it. Competition destroys capture; monopoly enables durable profit, long-term thinking, and reinvestment. Thiel&#x27;s practical...</span>
+        </a>
+        <a class="wiki-card" href="../concepts/operator-judgment-and-hiring.html">
+          <span class="wiki-card-title">Operator Judgement and Hiring</span>
+          <span class="wiki-card-description">Across Brian Chesky and Gokul Rajaram, the common hiring theme is that talent should be assessed through work, not performance in abstract interviews or managerial polish. Rajaram favours work projects that resemble...</span>
+        </a>
+        <a class="wiki-card" href="../concepts/pro-metabolic-nutrition.html">
+          <span class="wiki-card-title">Pro-Metabolic Nutrition</span>
+          <span class="wiki-card-description">Pro-metabolic nutrition is the food framework in kate-deering&#x27;s How to Heal Your Metabolism. It prioritises easy-to-digest foods that support thyroid function, blood sugar stability, mineral status, and low...</span>
+        </a>
+        <a class="wiki-card" href="../concepts/product-delight-and-craft.html">
+          <span class="wiki-card-title">Product Delight and Craft</span>
+          <span class="wiki-card-description">Kevin Hale&#x27;s lecture gives a craft-level version of building-products-users-love: products create emotional relationships with users through first impressions, small details, support, and long-term trust. Hale&#x27;s...</span>
+        </a>
+        <a class="wiki-card" href="../concepts/protein-quality-and-amino-acid-balance.html">
+          <span class="wiki-card-title">Protein Quality and Amino Acid Balance</span>
+          <span class="wiki-card-description">In Deering&#x27;s framework, protein is essential for structure, enzymes, hormones, immunity, repair, and transport, but it should not become the body&#x27;s main fuel. Protein quality depends on digestibility, amino-acid...</span>
+        </a>
+        <a class="wiki-card" href="../concepts/pufa-avoidance.html">
+          <span class="wiki-card-title">PUFA Avoidance</span>
+          <span class="wiki-card-description">PUFA avoidance is one of the strongest claims in kate-deering&#x27;s book. Deering argues that polyunsaturated fats — especially industrial seed oils and high-omega-6 oils — are unstable, oxidation-prone,...</span>
+        </a>
+        <a class="wiki-card" href="../concepts/rag-vs-compiled-knowledge.html">
+          <span class="wiki-card-title">RAG vs Compiled Knowledge</span>
+          <span class="wiki-card-description">Traditional RAG retrieves raw chunks at query time and asks the model to synthesize an answer from scratch. Compiled knowledge uses an intermediate, persistent wiki that has already integrated sources into summaries,...</span>
+        </a>
+        <a class="wiki-card" href="../concepts/software-moats.html">
+          <span class="wiki-card-title">Software Moats</span>
+          <span class="wiki-card-description">Gokul Rajaram&#x27;s 20VC framework lists eight moats for enduring software companies. The key rule is cumulative: one moat is weak; four or more moats suggest a company is relatively safe from competition; zero moats...</span>
+        </a>
+        <a class="wiki-card" href="../concepts/startup-counterintuition.html">
+          <span class="wiki-card-title">Startup Counterintuition</span>
+          <span class="wiki-card-description">Paul Graham&#x27;s lecture argues that startups are unusually counterintuitive: founders&#x27; normal instincts, especially instincts trained by school or large organisations, often lead them the wrong way. Graham&#x27;s idea...</span>
+        </a>
+        <a class="wiki-card" href="../concepts/startup-execution-and-operating-rhythm.html">
+          <span class="wiki-card-title">Startup Execution and Operating Rhythm</span>
+          <span class="wiki-card-description">Execution is the grind of choosing what matters, doing it fast, and maintaining momentum. YC treats execution as the founder&#x27;s non-delegable job: the company copies the founder&#x27;s operating standard. Sam Altman&#x27;s...</span>
+        </a>
+        <a class="wiki-card" href="../concepts/startup-fundraising.html">
+          <span class="wiki-card-title">Startup Fundraising</span>
+          <span class="wiki-card-description">YC&#x27;s fundraising advice is that fundraising is not success; it is a tool to remove risk and fund the next stage of company-building. The best fundraising strategy is to build a company so good investors cannot ignore...</span>
+        </a>
+        <a class="wiki-card" href="../concepts/startup-growth.html">
+          <span class="wiki-card-title">Startup Growth</span>
+          <span class="wiki-card-description">In the YC course, growth comes after product love. The strongest recurring claim is that retention is the foundation: if users do not stick, growth tactics only pour more users into a leaky bucket. alex-schultz...</span>
+        </a>
+        <a class="wiki-card" href="../concepts/startup-hiring-and-culture.html">
+          <span class="wiki-card-title">Startup Hiring and Culture</span>
+          <span class="wiki-card-description">Startup hiring is unusually high-leverage because the first few people set the culture, bar, and referral network for everyone after them. YC&#x27;s advice is to hire slowly at first, maintain a very high bar, and treat...</span>
+        </a>
+        <a class="wiki-card" href="../concepts/startup-ideas-and-markets.html">
+          <span class="wiki-card-title">Startup Ideas and Markets</span>
+          <span class="wiki-card-description">A startup idea is not just the product. In YC&#x27;s framing, it includes the market, growth strategy, defensibility, timing, and why the company can become important. The idea should come before the startup: founders...</span>
+        </a>
+        <a class="wiki-card" href="../concepts/startup-legal-and-accounting.html">
+          <span class="wiki-card-title">Startup Legal and Accounting</span>
+          <span class="wiki-card-description">Kirsty Nathoo and Carolynn Levy&#x27;s lecture is about startup mechanics founders should understand enough to avoid expensive mistakes, without letting mechanics become the company-building focus. Legal/accounting basics...</span>
+        </a>
+        <a class="wiki-card" href="../concepts/startup-management.html">
+          <span class="wiki-card-title">Startup Management</span>
+          <span class="wiki-card-description">Ben Horowitz&#x27;s management lecture centres on one hard rule: every management decision must be understood from the perspective of everyone affected, not only the person in the room. When making a critical decision,...</span>
+        </a>
+        <a class="wiki-card" href="../concepts/startup-operating-and-management.html">
+          <span class="wiki-card-title">Startup Operating and Management</span>
+          <span class="wiki-card-description">Operating is the work of turning a product into a company. keith-rabois frames the company as an engine: early on it is held together with duct tape and heroics; the goal is eventually a high-performance machine that...</span>
+        </a>
+        <a class="wiki-card" href="../concepts/startup-sales-and-marketing.html">
+          <span class="wiki-card-title">Startup Sales and Marketing</span>
+          <span class="wiki-card-description">Tyler Bosmeny&#x27;s sales lecture treats early sales as founder-led discovery and persistence, not a dark art performed by naturally charismatic salespeople. Early sales still has a funnel: prospecting, getting...</span>
+        </a>
+        <a class="wiki-card" href="../concepts/startup-user-research.html">
+          <span class="wiki-card-title">Startup User Research</span>
+          <span class="wiki-card-description">Startup user research is not a formal survey exercise. In the YC lectures, it means getting uncomfortably close to users, the industry, and the actual workflow before and during product building. Feedback quality...</span>
+        </a>
+        <a class="wiki-card" href="../concepts/thyroid-stress-hormones-and-energy-regulation.html">
+          <span class="wiki-card-title">Thyroid, Stress Hormones, and Energy Regulation</span>
+          <span class="wiki-card-description">Deering&#x27;s framework treats thyroid function as the conductor of metabolism. T4 is the main thyroid output, T3 is framed as the more active hormone, and conversion depends partly on adequate liver glycogen, nutrition,...</span>
+        </a>
+        <a class="wiki-card" href="../concepts/yc-how-to-start-a-startup.html">
+          <span class="wiki-card-title">YC How to Start a Startup</span>
+          <span class="wiki-card-description">Y Combinator&#x27;s How to Start a Startup is a startup/operator curriculum built around a simple thesis: hypergrowth startups require a great idea/market, a product users love, a strong team and culture, and relentless...</span>
+        </a>
+      </div>
+    </section>
+    <footer>
+      <span>© 2026 Jeison Sosa</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/concepts/jay-personal-knowledge-os.html
+++ b/wiki/concepts/jay-personal-knowledge-os.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Jay Personal Knowledge OS · Jay Sosa Wiki</title>
+    <meta name="description" content="Jay&#x27;s Personal Knowledge OS is the local implementation of the llm-wiki pattern: a Hermes-maintained, Obsidian-compatible wiki for durable research and synthesis. Jay curates sources and asks questions. Hermes...">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/concepts/jay-personal-knowledge-os.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-concept">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Concept</p>
+      <h1>Jay Personal Knowledge OS</h1>
+      <p class="meta">Concept · Updated 2026-05-27 · Confidence: medium</p>
+      <div class="wiki-tags"><span>knowledge-base</span><span>strategy</span><span>product</span><span>fintech</span><span>career</span><span>ai</span><span>operator</span></div>
+      <div class="wiki-content">
+<p>Jay's Personal Knowledge OS is the local implementation of the <a href="../concepts/llm-wiki.html">LLM Wiki</a> pattern: a Hermes-maintained, Obsidian-compatible wiki for durable research and synthesis.</p>
+<h2 id="intended-uses">Intended uses</h2>
+<ul>
+<li><strong>Company intelligence</strong>: persistent pages for companies Jay tracks, especially fintech/payments, AI, hard-tech, and enterprise SaaS.</li>
+<li><strong>Role and career research</strong>: reusable role/company fit analysis, interview prep, application themes, and positioning.</li>
+<li><strong>Product strategy</strong>: durable concepts around growth, GTM product management, commercial product ownership, payments, lending, and market expansion.</li>
+<li><strong>Founder/operator mental models</strong>: patterns from admired founders, operators, investors, and companies.</li>
+<li><strong>Essays and memos</strong>: reusable synthesis for future writing in Jay's preferred plain UK English style.</li>
+<li><strong>AI workflows</strong>: notes on agentic systems, LLM tooling, and Hermes workflows that improve Jay's operating leverage.</li>
+</ul>
+<h2 id="operating-model">Operating model</h2>
+<p>Jay curates sources and asks questions. Hermes maintains structure: raw source capture, compiled pages, links, index updates, logs, contradictions, and filed query outputs.</p>
+<h2 id="first-implementation-choice">First implementation choice</h2>
+<p>Start as a local markdown vault under <code>/Users/jay/.hermes/projects/wiki</code>, not as a web app or vector database. Add search, qmd, Dataview, cron linting, or Git sync later only when the wiki has enough content to justify it.</p>
+      </div>
+    </article>
+
+    <section class="wiki-related">
+      <h2>Related pages</h2>
+      <ul><li><a href="../concepts/llm-wiki.html">LLM Wiki</a></li></ul>
+    </section>
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/concepts/keith-rabois-operating-frameworks.html
+++ b/wiki/concepts/keith-rabois-operating-frameworks.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Keith Rabois Operating Frameworks · Jay Sosa Wiki</title>
+    <meta name="description" content="This page synthesises a user-provided deep research report on keith-rabois&#x27;s public educational frameworks across lectures, interviews, newsletters, and startup advice. The source frames Rabois&#x27;s operating philosophy...">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/concepts/keith-rabois-operating-frameworks.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-concept">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Concept</p>
+      <h1>Keith Rabois Operating Frameworks</h1>
+      <p class="meta">Concept · Updated 2026-05-28 · Confidence: medium</p>
+      <div class="wiki-tags"><span>operator</span><span>strategy</span><span>company</span></div>
+      <div class="wiki-content">
+<p>This page synthesises a user-provided deep research report on <a href="../entities/keith-rabois.html">Keith Rabois</a>'s public educational frameworks across lectures, interviews, newsletters, and startup advice. The source frames Rabois's operating philosophy as clarity over complexity, talent identification over process, and intentional rule-breaking over conventional startup theatre.</p>
+<h2 id="core-philosophy">Core philosophy</h2>
+<p>Rabois's recurring pattern is to turn messy founder problems into sharp operating metaphors. The common thread across his frameworks is that leaders should simplify reality enough to act: rank priorities instead of making vague pros/cons lists, delegate based on decision risk and team maturity, hire people who can carry ideas end-to-end, and build operating infrastructure that makes good judgement repeatable.</p>
+<h2 id="main-frameworks">Main frameworks</h2>
+<ul>
+<li><strong>Priority ranking over pros/cons:</strong> make decisions by ranking what matters most, then evaluate options against the top priority first. Avoid letting minor pros visually offset major cons.</li>
+<li><strong>Conviction-consequence delegation:</strong> delegate low-consequence or low-conviction decisions; intervene and explain when the consequence is catastrophic and founder conviction is high. See <a href="../concepts/conviction-consequence-delegation.html">Conviction-Consequence Delegation</a>.</li>
+<li><strong>Editing metaphor:</strong> CEOs are editors: simplify, clarify, allocate resources, preserve consistency, and edit the team.</li>
+<li><strong>Task-relevant maturity:</strong> management style depends on whether the person has done this exact task before, not on their generic seniority.</li>
+<li><strong>Barrels and ammunition:</strong> barrels can take an idea from inception to shipped outcome and pull people with them; ammunition are strong contributors who need direction. See <a href="../concepts/barrels-and-ammunition.html">Barrels and Ammunition</a>.</li>
+<li><strong>Undiscovered talent:</strong> look for high-slope people before the market has priced them; mentor and expand their responsibility quickly.</li>
+<li><strong>Fragmented industry + low NPS:</strong> large, fragmented, disliked industries can be attractive when a startup can vertically integrate a simpler product. See <a href="../concepts/fragmented-industry-vertical-integration.html">Fragmented Industry Vertical Integration</a>.</li>
+<li><strong>Metrics and transparency:</strong> dashboards, paired metrics, and broad context let people make better decisions without founder bottlenecks.</li>
+<li><strong>Contrarian rule-breaking:</strong> rules are not sacred; outlier startups often require knowing when to break conventional wisdom deliberately.</li>
+</ul>
+<h2 id="why-it-matters-for-jay">Why it matters for Jay</h2>
+<p>This is useful as an operator/PM lens: the question is not “what process should exist?” but “what operating judgement should the process encode?” Rabois's frameworks are particularly relevant for mini-CEO product work: prioritisation, cross-functional clarity, talent leverage, customer/problem selection, and avoiding process that obscures the real company constraint.</p>
+      </div>
+    </article>
+
+    <section class="wiki-related">
+      <h2>Related pages</h2>
+      <ul><li><a href="../entities/keith-rabois.html">Keith Rabois</a></li>
+<li><a href="../concepts/conviction-consequence-delegation.html">Conviction-Consequence Delegation</a></li>
+<li><a href="../concepts/barrels-and-ammunition.html">Barrels and Ammunition</a></li>
+<li><a href="../concepts/fragmented-industry-vertical-integration.html">Fragmented Industry Vertical Integration</a></li>
+<li><a href="../concepts/startup-execution-and-operating-rhythm.html">Startup Execution and Operating Rhythm</a></li>
+<li><a href="../concepts/startup-operating-and-management.html">Startup Operating and Management</a></li></ul>
+    </section>
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/concepts/later-stage-startup-scaling.html
+++ b/wiki/concepts/later-stage-startup-scaling.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Later-stage Startup Scaling · Jay Sosa Wiki</title>
+    <meta name="description" content="Later-stage scaling begins after product-market fit, often around months 12–24. Sam Altman&#x27;s main transition is that the founder&#x27;s job shifts from building a great product to building a great company. A flat...">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/concepts/later-stage-startup-scaling.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-concept">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Concept</p>
+      <h1>Later-stage Startup Scaling</h1>
+      <p class="meta">Concept · Updated 2026-05-28 · Confidence: high</p>
+      <div class="wiki-tags"><span>company</span><span>operator</span><span>strategy</span></div>
+      <div class="wiki-content">
+<p>Later-stage scaling begins after product-market fit, often around months 12–24. Sam Altman's main transition is that the founder's job shifts from building a great product to building a great company.</p>
+<h2 id="management-and-structure">Management and structure</h2>
+<p>A flat structure can work up to roughly 20–25 employees but can fail suddenly around 30. The required fix is not bureaucracy: everyone should know their manager, every manager should know their reports, and teams should have clear ownership.</p>
+<h2 id="common-founder-failures">Common founder failures</h2>
+<ul>
+<li>Being afraid to hire senior people after the company starts scaling.</li>
+<li>Staying in hero mode instead of pausing to hire and systematise.</li>
+<li>Delegating badly by making employees gather information while the founder makes all decisions.</li>
+<li>Lacking a personal organisation system to track goals, people, and follow-up.</li>
+</ul>
+<h2 id="hr-and-company-systems">HR and company systems</h2>
+<p>Good HR should speed the company up: clear career paths, frequent performance feedback, compensation bands, equity refreshers, burnout monitoring, a hiring process, onboarding, and legal/finance hygiene. Founders should write down the how and why of the company early; if they do not, culture becomes random oral tradition.</p>
+<h2 id="productivity-and-alignment">Productivity and alignment</h2>
+<p>As headcount grows, productivity decays unless alignment is actively maintained. Everyone should know the roadmap and top goals. Management meetings, all-hands, quarterly planning, and offsites become useful rhythms when they preserve product focus rather than process for its own sake.</p>
+<h2 id="founder-mode-addendum">Founder mode addendum</h2>
+<p><a href="../entities/brian-chesky.html">Brian Chesky</a> complicates the usual advice to delegate as the company scales. His <a href="../concepts/ai-founder-mode.html">AI Founder Mode</a> model says founders should start deeply hands-on, understand the details, train the organisation's muscle memory, and only then give ground. The scaling failure mode is not only founder heroics; it is also professional-management abstraction where the founder loses the steering wheel.</p>
+      </div>
+    </article>
+
+    <section class="wiki-related">
+      <h2>Related pages</h2>
+      <ul><li><a href="../entities/brian-chesky.html">Brian Chesky</a></li>
+<li><a href="../concepts/ai-founder-mode.html">AI Founder Mode</a></li>
+<li><a href="../concepts/startup-hiring-and-culture.html">Startup Hiring and Culture</a></li>
+<li><a href="../concepts/yc-how-to-start-a-startup.html">YC How to Start a Startup</a></li></ul>
+    </section>
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/concepts/llm-wiki.html
+++ b/wiki/concepts/llm-wiki.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>LLM Wiki · Jay Sosa Wiki</title>
+    <meta name="description" content="An LLM Wiki is a persistent, agent-maintained markdown knowledge base where an LLM incrementally compiles sources into structured, cross-linked pages. The key distinction from ordinary retrieval is that knowledge is...">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/concepts/llm-wiki.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-concept">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Concept</p>
+      <h1>LLM Wiki</h1>
+      <p class="meta">Concept · Updated 2026-05-27 · Confidence: high</p>
+      <div class="wiki-tags"><span>knowledge-base</span><span>llm</span><span>agent-workflow</span><span>research</span><span>obsidian</span></div>
+      <div class="wiki-content">
+<p>An LLM Wiki is a persistent, agent-maintained markdown knowledge base where an LLM incrementally compiles sources into structured, cross-linked pages. The key distinction from ordinary retrieval is that knowledge is integrated once and then maintained, rather than rediscovered from raw chunks on every query.</p>
+<p>The architecture has three layers:</p>
+<ul>
+<li><strong>Raw sources</strong>: immutable source documents under <code>raw/</code>.</li>
+<li><strong>Compiled wiki</strong>: summaries, entity pages, concept pages, comparisons, and filed queries maintained by the agent.</li>
+<li><strong>Schema</strong>: rules such as this wiki's <code>SCHEMA.md</code>, which define page formats, naming, links, indexing, logging, and update policy.</li>
+</ul>
+<p>The wiki should compound. Each source can update many pages, strengthen or challenge existing synthesis, and create links that future queries can reuse.</p>
+<h2 id="why-it-matters">Why it matters</h2>
+<p>For Jay, the pattern turns recurring research into a durable asset: company research, fintech/payments analysis, role prep, product strategy memos, and essay ideas can accumulate in one navigable system instead of staying scattered across chats and source files.</p>
+<h2 id="operating-principles">Operating principles</h2>
+<ul>
+<li>Raw sources stay immutable.</li>
+<li>The agent owns bookkeeping and maintenance.</li>
+<li>The human curates sources and directs judgement.</li>
+<li>Queries should read from compiled pages first.</li>
+<li>Valuable answers should be filed back into the wiki.</li>
+</ul>
+      </div>
+    </article>
+
+    <section class="wiki-related">
+      <h2>Related pages</h2>
+      <ul><li><a href="../concepts/jay-personal-knowledge-os.html">Jay Personal Knowledge OS</a></li></ul>
+    </section>
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/concepts/metabolic-lifestyle-recovery.html
+++ b/wiki/concepts/metabolic-lifestyle-recovery.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Metabolic Lifestyle Recovery · Jay Sosa Wiki</title>
+    <meta name="description" content="Deering argues that food is necessary but not sufficient. Sleep, exercise dose, hydration, work stress, relationships, emotional state, and community all affect metabolic recovery. Good nutrition is a “bulletproof...">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/concepts/metabolic-lifestyle-recovery.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-concept">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Concept</p>
+      <h1>Metabolic Lifestyle Recovery</h1>
+      <p class="meta">Concept · Updated 2026-05-28 · Confidence: medium</p>
+      <div class="wiki-tags"><span>health</span><span>nutrition</span><span>metabolism</span></div>
+      <div class="wiki-content">
+<p>Deering argues that food is necessary but not sufficient. Sleep, exercise dose, hydration, work stress, relationships, emotional state, and community all affect metabolic recovery.</p>
+<h2 id="main-practices">Main practices</h2>
+<ul>
+<li><strong>Sleep:</strong> protect sleep as a repair process; night waking may reflect poor liver glycogen and stress-hormone spikes.</li>
+<li><strong>Exercise:</strong> treat exercise as a stressor. Reduce intense cardio/HIIT/CrossFit/excess lifting when recovery is poor; use walking, gentle yoga, easy swimming, tai chi, or light weights; intensify later.</li>
+<li><strong>Hydration:</strong> drink to thirst rather than ideology. Avoid excessive plain water when it worsens coldness, frequent urination, bloating, or sleep; prefer mineral/sugar-containing fluids when appropriate.</li>
+<li><strong>Stress and happiness:</strong> chronic work, relationship, identity, and community stress are metabolic inputs, not separate from physical health.</li>
+<li><strong>Implementation:</strong> make changes gradually, track responses, and expect healing to take months to years.</li>
+</ul>
+<h2 id="mental-model">Mental model</h2>
+<p>Good nutrition is a “bulletproof vest”, not a way to survive an endless battlefield. If stress exposure remains too high, even a metabolically supportive diet may not restore energy.</p>
+      </div>
+    </article>
+
+    <section class="wiki-related">
+      <h2>Related pages</h2>
+      <ul><li><a href="../concepts/how-to-heal-your-metabolism.html">How to Heal Your Metabolism</a></li></ul>
+    </section>
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/concepts/metabolism-as-a-health-model.html
+++ b/wiki/concepts/metabolism-as-a-health-model.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Metabolism as a Health Model · Jay Sosa Wiki</title>
+    <meta name="description" content="In kate-deering&#x27;s How to Heal Your Metabolism, health is defined less as weight, lab normality, or visible fitness and more as a high cellular energy state. A well-functioning metabolism should produce warmth, good...">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/concepts/metabolism-as-a-health-model.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-concept">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Concept</p>
+      <h1>Metabolism as a Health Model</h1>
+      <p class="meta">Concept · Updated 2026-05-28 · Confidence: medium</p>
+      <div class="wiki-tags"><span>health</span><span>nutrition</span><span>metabolism</span></div>
+      <div class="wiki-content">
+<p>In <a href="../entities/kate-deering.html">Kate Deering</a>'s <em>How to Heal Your Metabolism</em>, health is defined less as weight, lab normality, or visible fitness and more as a high cellular energy state. A well-functioning metabolism should produce warmth, good digestion, restorative sleep, clear mood, adequate libido, fertility, immunity, and resilient body composition.</p>
+<h2 id="markers-deering-uses">Markers Deering uses</h2>
+<ul>
+<li>Morning and daytime body temperature, aiming roughly towards 97.8–98.6°F.</li>
+<li>Resting pulse, often framed as roughly 75–90 bpm.</li>
+<li>Warm hands and feet.</li>
+<li>Regular bowel movements.</li>
+<li>Stable energy, appetite, mood, and sleep.</li>
+<li>Good libido, menstrual/hormonal health, hair, skin, nails, digestion, and immunity.</li>
+</ul>
+<h2 id="mental-model">Mental model</h2>
+<p>The model treats the body like an energy economy. When thyroid-led energy production is strong, the body can repair, digest, reproduce, sleep, and tolerate stress. When energy production is weak, the body compensates with adrenaline and cortisol, producing short-term functionality but long-term fragility.</p>
+<h2 id="how-to-use-this-page">How to use this page</h2>
+<p>This is a useful self-observation lens, not a diagnostic system. Temperature, pulse, sleep, stool, mood, and food tolerance can reveal patterns that a single lab value misses, but they are affected by infection, medication, anxiety, menstrual cycle, fitness, caffeine, hydration, and environment.</p>
+      </div>
+    </article>
+
+    <section class="wiki-related">
+      <h2>Related pages</h2>
+      <ul><li><a href="../entities/kate-deering.html">Kate Deering</a></li>
+<li><a href="../concepts/how-to-heal-your-metabolism.html">How to Heal Your Metabolism</a></li></ul>
+    </section>
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/concepts/monopoly-theory.html
+++ b/wiki/concepts/monopoly-theory.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Monopoly Theory · Jay Sosa Wiki</title>
+    <meta name="description" content="Peter Thiel&#x27;s lecture argues that valuable companies both create value and capture part of it. Competition destroys capture; monopoly enables durable profit, long-term thinking, and reinvestment. Thiel&#x27;s practical...">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/concepts/monopoly-theory.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-concept">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Concept</p>
+      <h1>Monopoly Theory</h1>
+      <p class="meta">Concept · Updated 2026-05-27 · Confidence: high</p>
+      <div class="wiki-tags"><span>strategy</span><span>market</span><span>investing</span></div>
+      <div class="wiki-content">
+<p>Peter Thiel's lecture argues that valuable companies both create value and capture part of it. Competition destroys capture; monopoly enables durable profit, long-term thinking, and reinvestment.</p>
+<h2 id="monopoly-vs-competition">Monopoly vs competition</h2>
+<ul>
+<li>Perfect competition is easy to model but brutal to operate in: profits are competed away.</li>
+<li>Monopoly does not mean illegal coercion here; it means being the only company that matters in a differentiated market.</li>
+<li>Competitive companies exaggerate their uniqueness by defining markets too narrowly.</li>
+<li>Monopoly companies often hide their dominance by defining markets too broadly.</li>
+</ul>
+<h2 id="start-small-and-dominate">Start small and dominate</h2>
+<p>Thiel's practical startup advice is to begin with a small market where the company can become dominant, then expand adjacent markets. A giant day-one market usually means the category is too broad and the company will face too much competition.</p>
+<h2 id="characteristics-of-durable-monopoly">Characteristics of durable monopoly</h2>
+<p>The lecture points to several recurring monopoly traits:</p>
+<ul>
+<li>proprietary technology or product advantage;</li>
+<li>network effects;</li>
+<li>economies of scale;</li>
+<li>brand;</li>
+<li>a sequencing strategy from a narrow initial market into a much larger one.</li>
+</ul>
+<h2 id="relationship-to-other-wiki-ideas">Relationship to other wiki ideas</h2>
+<p>This is the sharper strategy version of <a href="../concepts/startup-ideas-and-markets.html">Startup Ideas and Markets</a>: market size matters less than the path to becoming the one-of-a-kind company in a valuable niche. It also links to <a href="../concepts/startup-fundraising.html">Startup Fundraising</a>, because venture investors are paid to find outlier companies, not merely competent businesses.</p>
+<h2 id="software-moats-addendum">Software moats addendum</h2>
+<p><a href="../concepts/software-moats.html">Software Moats</a> extends the monopoly lens into a practical software diligence checklist. In Thiel's terms, the question is not only whether the company has a differentiated market position, but whether it stacks hard-to-copy defences: proprietary data, deep integration, regulatory locks, channel control, ecosystem lock-in, network effects, physical infrastructure, and scale economics.</p>
+      </div>
+    </article>
+
+    <section class="wiki-related">
+      <h2>Related pages</h2>
+      <ul><li><a href="../concepts/startup-ideas-and-markets.html">Startup Ideas and Markets</a></li>
+<li><a href="../concepts/startup-fundraising.html">Startup Fundraising</a></li>
+<li><a href="../concepts/software-moats.html">Software Moats</a></li>
+<li><a href="../concepts/founder-80-20-principle.html">Founder 80/20 Principle</a></li>
+<li><a href="../concepts/fragmented-industry-vertical-integration.html">Fragmented Industry Vertical Integration</a></li></ul>
+    </section>
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/concepts/operator-judgment-and-hiring.html
+++ b/wiki/concepts/operator-judgment-and-hiring.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Operator Judgement and Hiring · Jay Sosa Wiki</title>
+    <meta name="description" content="Across Brian Chesky and Gokul Rajaram, the common hiring theme is that talent should be assessed through work, not performance in abstract interviews or managerial polish. Rajaram favours work projects that resemble...">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/concepts/operator-judgment-and-hiring.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-concept">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Concept</p>
+      <h1>Operator Judgement and Hiring</h1>
+      <p class="meta">Concept · Updated 2026-05-28 · Confidence: medium</p>
+      <div class="wiki-tags"><span>operator</span><span>company</span><span>career</span><span>strategy</span></div>
+      <div class="wiki-content">
+<p>Across Brian Chesky and Gokul Rajaram, the common hiring theme is that talent should be assessed through work, not performance in abstract interviews or managerial polish.</p>
+<h2 id="work-projects-reveal-agency">Work projects reveal agency</h2>
+<p>Rajaram favours work projects that resemble the actual job. For PMs, ask whether a product should be built; the best candidates may reject the premise after talking to customers. DoorDash used an extreme version: give candidates a tiny budget and ask them to acquire customers, not because anyone will hit the target, but to see how many creative attempts they make.</p>
+<h2 id="hiring-beats-management">Hiring beats management</h2>
+<p>Chesky argues the CEO can spend time hiring or managing. The better the people, the less they need to be managed. His operating habit is pipeline recruiting: constantly meeting excellent people before searches exist, asking each person who else is exceptional, and building talent maps around actual work and referrals.</p>
+<h2 id="start-with-the-result-work-backwards">Start with the result, work backwards</h2>
+<p>For hiring, Chesky advises starting with a piece of excellent work and finding who made it, rather than starting with a prestigious company or resume. The same logic applies to company building: observable artefacts beat status proxies.</p>
+<h2 id="management-through-the-work">Management through the work</h2>
+<p>In AI founder mode, pure people management weakens. Managers need contact with reality and craft. The leader's role is to raise standards through the work, not to become a therapist or coordinator detached from the output.</p>
+      </div>
+    </article>
+
+    <section class="wiki-related">
+      <h2>Related pages</h2>
+      <ul><li><a href="../concepts/startup-operating-and-management.html">Startup Operating and Management</a></li></ul>
+    </section>
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/concepts/pro-metabolic-nutrition.html
+++ b/wiki/concepts/pro-metabolic-nutrition.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Pro-Metabolic Nutrition · Jay Sosa Wiki</title>
+    <meta name="description" content="Pro-metabolic nutrition is the food framework in kate-deering&#x27;s How to Heal Your Metabolism. It prioritises easy-to-digest foods that support thyroid function, blood sugar stability, mineral status, and low...">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/concepts/pro-metabolic-nutrition.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-concept">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Concept</p>
+      <h1>Pro-Metabolic Nutrition</h1>
+      <p class="meta">Concept · Updated 2026-05-28 · Confidence: medium</p>
+      <div class="wiki-tags"><span>health</span><span>nutrition</span><span>metabolism</span></div>
+      <div class="wiki-content">
+<p>Pro-metabolic nutrition is the food framework in <a href="../entities/kate-deering.html">Kate Deering</a>'s <em>How to Heal Your Metabolism</em>. It prioritises easy-to-digest foods that support thyroid function, blood sugar stability, mineral status, and low stress-hormone reliance.</p>
+<h2 id="preferred-pattern">Preferred pattern</h2>
+<ul>
+<li><strong>Carbohydrates:</strong> fruit, pulp-free orange juice, honey, milk, ripe/cooked fruit, coconut water, potatoes and selected roots, with grains only in moderation and only when digestion is robust.</li>
+<li><strong>Proteins:</strong> milk, cheese, eggs, liver, shellfish, white fish, potato protein, gelatin, collagen, and bone broth.</li>
+<li><strong>Fats:</strong> coconut oil, butter, ghee, cacao, beef fat/lard, and modest olive oil as dressing.</li>
+<li><strong>Mineral supports:</strong> salt, dairy calcium, eggshell calcium when dairy is insufficient, shellfish minerals, orange juice/potassium, coffee with calories, and broths.</li>
+<li><strong>Foods to limit during healing:</strong> seed oils, nuts/seeds, legumes/soy, grains/gluten, raw fibrous vegetables, heavy muscle-meat reliance, protein powders, alcohol, and processed foods.</li>
+</ul>
+<h2 id="decision-rule">Decision rule</h2>
+<p>Deering's rule is not “natural food good, processed food bad” alone. It is: does this food provide usable energy and nutrients without creating a digestion, blood sugar, thyroid, PUFA, or stress-hormone burden?</p>
+      </div>
+    </article>
+
+    <section class="wiki-related">
+      <h2>Related pages</h2>
+      <ul><li><a href="../entities/kate-deering.html">Kate Deering</a></li>
+<li><a href="../concepts/how-to-heal-your-metabolism.html">How to Heal Your Metabolism</a></li></ul>
+    </section>
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/concepts/product-delight-and-craft.html
+++ b/wiki/concepts/product-delight-and-craft.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Product Delight and Craft · Jay Sosa Wiki</title>
+    <meta name="description" content="Kevin Hale&#x27;s lecture gives a craft-level version of building-products-users-love: products create emotional relationships with users through first impressions, small details, support, and long-term trust. Hale&#x27;s...">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/concepts/product-delight-and-craft.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-concept">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Concept</p>
+      <h1>Product Delight and Craft</h1>
+      <p class="meta">Concept · Updated 2026-05-27 · Confidence: high</p>
+      <div class="wiki-tags"><span>product</span><span>strategy</span></div>
+      <div class="wiki-content">
+<p>Kevin Hale's lecture gives a craft-level version of <a href="../concepts/building-products-users-love.html">Building Products Users Love</a>: products create emotional relationships with users through first impressions, small details, support, and long-term trust.</p>
+<h2 id="dating-and-marriage-metaphor">Dating and marriage metaphor</h2>
+<ul>
+<li>New-user acquisition is like dating: first impressions, onboarding, copy, documentation, empty states, and error states shape whether the user feels cared for.</li>
+<li>Retention is like marriage: the product must repeatedly show responsiveness, reliability, and respect.</li>
+<li>The product relationship decays if negative interactions outnumber positive ones.</li>
+</ul>
+<h2 id="design-details-are-not-decoration">Design details are not decoration</h2>
+<p>Hale's examples — Wufoo, Stripe documentation, playful signup forms, human copy, 404 pages, and onboarding moments — point to a broader product principle: details signal whether the company cares. Documentation, billing, support, and error handling are all product surface area.</p>
+<h2 id="support-as-product-development">Support as product development</h2>
+<p>Great support is not a cost centre in early product work. It reveals user confusion, turns frustration into trust, and gives founders direct signal on where the product experience is failing.</p>
+      </div>
+    </article>
+
+    <section class="wiki-related">
+      <h2>Related pages</h2>
+      <ul><li><a href="../concepts/building-products-users-love.html">Building Products Users Love</a></li></ul>
+    </section>
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/concepts/protein-quality-and-amino-acid-balance.html
+++ b/wiki/concepts/protein-quality-and-amino-acid-balance.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Protein Quality and Amino Acid Balance · Jay Sosa Wiki</title>
+    <meta name="description" content="In Deering&#x27;s framework, protein is essential for structure, enzymes, hormones, immunity, repair, and transport, but it should not become the body&#x27;s main fuel. Protein quality depends on digestibility, amino-acid...">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/concepts/protein-quality-and-amino-acid-balance.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-concept">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Concept</p>
+      <h1>Protein Quality and Amino Acid Balance</h1>
+      <p class="meta">Concept · Updated 2026-05-28 · Confidence: medium</p>
+      <div class="wiki-tags"><span>health</span><span>nutrition</span><span>metabolism</span></div>
+      <div class="wiki-content">
+<p>In Deering's framework, protein is essential for structure, enzymes, hormones, immunity, repair, and transport, but it should not become the body's main fuel. Protein quality depends on digestibility, amino-acid balance, mineral context, and food processing.</p>
+<h2 id="preferred-proteins">Preferred proteins</h2>
+<p>The book's “super proteins” are milk/dairy, eggs, liver, shellfish, white fish, potato protein, gelatin, collagen, and bone broth. These are framed as more digestible, nutrient-dense, mineral-supportive, or amino-acid-balanced than large amounts of muscle meat.</p>
+<h2 id="muscle-meat-caveat">Muscle meat caveat</h2>
+<p>Muscle meats are not banned but are moderated. Deering worries about high phosphorus relative to calcium, digestive burden, conventional meat quality, and excess inflammatory amino acids. She recommends pairing meat with gelatin or bone broth to add glycine-rich connective-tissue protein.</p>
+<h2 id="protein-powders">Protein powders</h2>
+<p>Protein powders are criticised as processed foods with additives, sweeteners, damaged proteins, possible contaminants, and poor food context. Collagen/gelatin is the main exception, though it is not a complete protein for muscle-building.</p>
+      </div>
+    </article>
+
+    <section class="wiki-related">
+      <h2>Related pages</h2>
+      <ul><li><a href="../concepts/how-to-heal-your-metabolism.html">How to Heal Your Metabolism</a></li></ul>
+    </section>
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/concepts/pufa-avoidance.html
+++ b/wiki/concepts/pufa-avoidance.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>PUFA Avoidance · Jay Sosa Wiki</title>
+    <meta name="description" content="PUFA avoidance is one of the strongest claims in kate-deering&#x27;s book. Deering argues that polyunsaturated fats — especially industrial seed oils and high-omega-6 oils — are unstable, oxidation-prone,...">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/concepts/pufa-avoidance.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-concept">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Concept</p>
+      <h1>PUFA Avoidance</h1>
+      <p class="meta">Concept · Updated 2026-05-28 · Confidence: medium</p>
+      <div class="wiki-tags"><span>health</span><span>nutrition</span><span>metabolism</span></div>
+      <div class="wiki-content">
+<p>PUFA avoidance is one of the strongest claims in <a href="../entities/kate-deering.html">Kate Deering</a>'s book. Deering argues that polyunsaturated fats — especially industrial seed oils and high-omega-6 oils — are unstable, oxidation-prone, thyroid-suppressive, fattening, and anti-metabolic.</p>
+<h2 id="foods-oils-targeted">Foods/oils targeted</h2>
+<p>The book warns against grapeseed, corn, walnut, cottonseed, soybean, sesame, peanut, almond, canola, flaxseed, margarine, fish oil, cod liver oil, evening primrose/borage oils, nuts, seeds, soy products, and high-PUFA non-ruminant animal fats from corn/soy-fed poultry and pork.</p>
+<h2 id="preferred-alternative">Preferred alternative</h2>
+<p>Deering favours stable saturated fats: coconut oil, butter, ghee, cacao, and ruminant animal fats. Olive oil is accepted in moderation but not for high-heat cooking.</p>
+<h2 id="why-it-matters-in-the-framework">Why it matters in the framework</h2>
+<p>PUFA avoidance links several chapters together: saturated fat defence, seed/nut/legume scepticism, fish-oil critique, poultry/pork caution, and preference for dairy, shellfish, white fish, gelatin, fruit, and saturated cooking fats.</p>
+<h2 id="caveat">Caveat</h2>
+<p>This is highly contested. Many mainstream nutrition guidelines recommend replacing saturated fat with unsaturated fats. A more careful interpretation is to distinguish industrial, oxidised, ultra-processed seed-oil exposure from all PUFA-containing whole foods.</p>
+      </div>
+    </article>
+
+    <section class="wiki-related">
+      <h2>Related pages</h2>
+      <ul><li><a href="../entities/kate-deering.html">Kate Deering</a></li>
+<li><a href="../concepts/how-to-heal-your-metabolism.html">How to Heal Your Metabolism</a></li></ul>
+    </section>
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/concepts/rag-vs-compiled-knowledge.html
+++ b/wiki/concepts/rag-vs-compiled-knowledge.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>RAG vs Compiled Knowledge · Jay Sosa Wiki</title>
+    <meta name="description" content="Traditional RAG retrieves raw chunks at query time and asks the model to synthesize an answer from scratch. Compiled knowledge uses an intermediate, persistent wiki that has already integrated sources into summaries,...">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/concepts/rag-vs-compiled-knowledge.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-concept">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Concept</p>
+      <h1>RAG vs Compiled Knowledge</h1>
+      <p class="meta">Concept · Updated 2026-05-27 · Confidence: high</p>
+      <div class="wiki-tags"><span>knowledge-base</span><span>llm</span><span>ai</span><span>research</span><span>comparison</span></div>
+      <div class="wiki-content">
+<p>Traditional RAG retrieves raw chunks at query time and asks the model to synthesize an answer from scratch. Compiled knowledge uses an intermediate, persistent wiki that has already integrated sources into summaries, concept pages, entity pages, contradictions, and cross-links.</p>
+<h2 id="rag-pattern">RAG pattern</h2>
+<ul>
+<li>Sources are indexed as chunks.</li>
+<li>Retrieval happens at query time.</li>
+<li>Synthesis is re-created for each question.</li>
+<li>Cross-document insights may be rediscovered repeatedly.</li>
+<li>Little knowledge accumulates between queries unless added manually.</li>
+</ul>
+<h2 id="compiled-knowledge-pattern">Compiled knowledge pattern</h2>
+<ul>
+<li>Sources are first ingested into a structured wiki.</li>
+<li>Synthesis persists as markdown pages.</li>
+<li>Cross-links, contradictions, and summaries accumulate.</li>
+<li>Queries read the compiled layer first.</li>
+<li>Good query answers can become new wiki pages.</li>
+</ul>
+<h2 id="practical-implication">Practical implication</h2>
+<p>For Jay's use cases, compiled knowledge is better for themes that recur over weeks or months: companies, sectors, product patterns, founder/operator ideas, and career positioning. RAG is still useful for large-scale search, but it should augment the wiki later rather than replace it at the start.</p>
+      </div>
+    </article>
+
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/concepts/software-moats.html
+++ b/wiki/concepts/software-moats.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Software Moats · Jay Sosa Wiki</title>
+    <meta name="description" content="Gokul Rajaram&#x27;s 20VC framework lists eight moats for enduring software companies. The key rule is cumulative: one moat is weak; four or more moats suggest a company is relatively safe from competition; zero moats...">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/concepts/software-moats.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-concept">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Concept</p>
+      <h1>Software Moats</h1>
+      <p class="meta">Concept · Updated 2026-05-27 · Confidence: medium</p>
+      <div class="wiki-tags"><span>strategy</span><span>company</span><span>market</span><span>investing</span><span>ai</span></div>
+      <div class="wiki-content">
+<p>Gokul Rajaram's 20VC framework lists eight moats for enduring software companies. The key rule is cumulative: one moat is weak; four or more moats suggest a company is relatively safe from competition; zero moats suggests fragility.</p>
+<h2 id="the-eight-moats">The eight moats</h2>
+<ol>
+<li><strong>Secret data</strong> — unique proprietary information accumulated over years, such as Spotify's listening history powering recommendations.</li>
+<li><strong>Deep integration</strong> — software woven into daily operations and core workflows, such as NetSuite running company finance and operations.</li>
+<li><strong>Regulatory locks</strong> — licences, certifications, or compliance status that are hard to obtain, such as Coinbase money-transmission licences.</li>
+<li><strong>Control of sales channels</strong> — privileged access to the customer path, such as Intuit/QuickBooks influence through accountants.</li>
+<li><strong>Ecosystem lock-in</strong> — a developer/app/tool ecosystem that is hard to recreate, such as Shopify's merchant app ecosystem.</li>
+<li><strong>Network effects</strong> — the service improves as more participants use it, such as DoorDash's driver, restaurant, customer, and delivery-history network.</li>
+<li><strong>Physical stuff</strong> — hard-to-replicate physical infrastructure: factories, robots, servers, logistics, or other atoms.</li>
+<li><strong>Size advantage</strong> — scale economics that let a company offer lower prices or better economics than rivals, such as Amazon or TSMC.</li>
+</ol>
+<h2 id="synthesis">Synthesis</h2>
+<p>The framework is useful because it separates <em>software that is easy to copy</em> from <em>companies that are hard to displace</em>. It also updates <a href="../concepts/monopoly-theory.html">Monopoly Theory</a> for software and AI: a product feature may be cloned quickly, but accumulated data, workflow embedding, regulated permissions, distribution channels, ecosystems, networks, atoms, and scale are harder to clone.</p>
+<h2 id="how-to-use-it">How to use it</h2>
+<p>For company analysis, score each moat as absent, weak, emerging, or strong. A durable software company should not rely on a single defence. The strongest cases stack several moats: for example, an embedded financial infrastructure company might combine deep integration, regulatory locks, proprietary data, ecosystem partners, and scale economics.</p>
+<h2 id="ai-era-addendum">AI-era addendum</h2>
+<p>The two Gokul Rajaram podcast transcripts reinforce that software moats are now a response to cheap code. Thin AI wrappers are exposed; stronger companies stack moats and, in AI-native categories, may need to own the system of record or full workflow rather than merely sit on top of an incumbent API. See <a href="../concepts/ai-native-software-business-models.html">AI-native Software Business Models</a>.</p>
+      </div>
+    </article>
+
+    <section class="wiki-related">
+      <h2>Related pages</h2>
+      <ul><li><a href="../concepts/monopoly-theory.html">Monopoly Theory</a></li>
+<li><a href="../concepts/ai-native-software-business-models.html">AI-native Software Business Models</a></li>
+<li><a href="../concepts/enterprise-software-startups.html">Enterprise Software Startups</a></li>
+<li><a href="../concepts/fragmented-industry-vertical-integration.html">Fragmented Industry Vertical Integration</a></li>
+<li><a href="../concepts/startup-ideas-and-markets.html">Startup Ideas and Markets</a></li>
+<li><a href="../entities/gokul-rajaram.html">Gokul Rajaram</a></li></ul>
+    </section>
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/concepts/startup-counterintuition.html
+++ b/wiki/concepts/startup-counterintuition.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Startup Counterintuition · Jay Sosa Wiki</title>
+    <meta name="description" content="Paul Graham&#x27;s lecture argues that startups are unusually counterintuitive: founders&#x27; normal instincts, especially instincts trained by school or large organisations, often lead them the wrong way. Graham&#x27;s idea...">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/concepts/startup-counterintuition.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-concept">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Concept</p>
+      <h1>Startup Counterintuition</h1>
+      <p class="meta">Concept · Updated 2026-05-27 · Confidence: high</p>
+      <div class="wiki-tags"><span>strategy</span><span>operator</span></div>
+      <div class="wiki-content">
+<p>Paul Graham's lecture argues that startups are unusually counterintuitive: founders' normal instincts, especially instincts trained by school or large organisations, often lead them the wrong way.</p>
+<h2 id="core-claims">Core claims</h2>
+<ul>
+<li><strong>Do not trust startup instincts by default.</strong> Starting a startup is like skiing: some correct moves feel unnatural until learned.</li>
+<li><strong>Trust instincts about people more than instincts about “business”.</strong> Founders often misread business mechanics, but their lifetime of judging people remains useful.</li>
+<li><strong>Startup expertise is less important than user and problem expertise.</strong> Mark Zuckerberg did not win because he knew startup mechanics; he built something users wanted.</li>
+<li><strong>Stop playing house.</strong> Incorporation, advisors, pitch decks, conferences, and “startup” rituals can become substitutes for making something people want.</li>
+<li><strong>Gaming the system stops working.</strong> There is no professor or boss to fool; users only care whether the product solves their problem.</li>
+<li><strong>Startups are all-consuming.</strong> The successful case does not make life easier; it changes the type and scale of problems.</li>
+</ul>
+<h2 id="idea-generation">Idea generation</h2>
+<p>Graham's idea advice complements <a href="../concepts/startup-ideas-and-markets.html">Startup Ideas and Markets</a>: live in the future, notice what's missing, and build what seems obviously needed to a small group before it seems obvious to everyone else.</p>
+      </div>
+    </article>
+
+    <section class="wiki-related">
+      <h2>Related pages</h2>
+      <ul><li><a href="../concepts/startup-ideas-and-markets.html">Startup Ideas and Markets</a></li></ul>
+    </section>
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/concepts/startup-execution-and-operating-rhythm.html
+++ b/wiki/concepts/startup-execution-and-operating-rhythm.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Startup Execution and Operating Rhythm · Jay Sosa Wiki</title>
+    <meta name="description" content="Execution is the grind of choosing what matters, doing it fast, and maintaining momentum. YC treats execution as the founder&#x27;s non-delegable job: the company copies the founder&#x27;s operating standard. Sam Altman&#x27;s...">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/concepts/startup-execution-and-operating-rhythm.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-concept">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Concept</p>
+      <h1>Startup Execution and Operating Rhythm</h1>
+      <p class="meta">Concept · Updated 2026-05-28 · Confidence: high</p>
+      <div class="wiki-tags"><span>operator</span><span>strategy</span><span>company</span></div>
+      <div class="wiki-content">
+<p>Execution is the grind of choosing what matters, doing it fast, and maintaining momentum. YC treats execution as the founder's non-delegable job: the company copies the founder's operating standard.</p>
+<h2 id="focus-and-intensity">Focus and intensity</h2>
+<p>Sam Altman's execution frame has two parts:</p>
+<ul>
+<li><strong>Focus:</strong> choose the two or three things that matter and say no to almost everything else.</li>
+<li><strong>Intensity:</strong> move quickly, make decisions, and outwork competitors on the right things.</li>
+</ul>
+<p>Momentum is the lifeblood of a startup. When momentum sags, speeches rarely help; small wins, product progress, sales, or shipped features restore belief.</p>
+<h2 id="operating-rhythm">Operating rhythm</h2>
+<p>Useful rhythms include weekly metric reviews, regular shipping cadence, clear company goals, and direct repetition of priorities. Founders should assume that one all-hands announcement is not enough: alignment requires repetition.</p>
+<h2 id="details-and-standards">Details and standards</h2>
+<p><a href="../entities/keith-rabois.html">Keith Rabois</a> adds that founders are editors: simplify, clarify, allocate resources, preserve consistent voice, and edit the team. Excellence in details, even seemingly internal ones, creates a culture where quality is normal.</p>
+<h2 id="priority-ranking-addendum">Priority ranking addendum</h2>
+<p><a href="../concepts/keith-rabois-operating-frameworks.html">Keith Rabois Operating Frameworks</a> adds a decision rhythm: rank priorities rather than maintaining loose pros/cons lists. The highest priority should decide most trade-offs; only when options tie on priority one should the team move to priority two.</p>
+      </div>
+    </article>
+
+    <section class="wiki-related">
+      <h2>Related pages</h2>
+      <ul><li><a href="../entities/keith-rabois.html">Keith Rabois</a></li>
+<li><a href="../concepts/keith-rabois-operating-frameworks.html">Keith Rabois Operating Frameworks</a></li>
+<li><a href="../concepts/founder-80-20-principle.html">Founder 80/20 Principle</a></li>
+<li><a href="../concepts/yc-how-to-start-a-startup.html">YC How to Start a Startup</a></li></ul>
+    </section>
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/concepts/startup-fundraising.html
+++ b/wiki/concepts/startup-fundraising.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Startup Fundraising · Jay Sosa Wiki</title>
+    <meta name="description" content="YC&#x27;s fundraising advice is that fundraising is not success; it is a tool to remove risk and fund the next stage of company-building. The best fundraising strategy is to build a company so good investors cannot ignore...">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/concepts/startup-fundraising.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-concept">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Concept</p>
+      <h1>Startup Fundraising</h1>
+      <p class="meta">Concept · Updated 2026-05-27 · Confidence: high</p>
+      <div class="wiki-tags"><span>investing</span><span>strategy</span><span>company</span></div>
+      <div class="wiki-content">
+<p>YC's fundraising advice is that fundraising is not success; it is a tool to remove risk and fund the next stage of company-building. The best fundraising strategy is to build a company so good investors cannot ignore it.</p>
+<h2 id="investor-decision-criteria">Investor decision criteria</h2>
+<p>Ron Conway looks for leadership, communication, decisiveness, product obsession, and often a personal problem behind the product. Marc Andreessen emphasises that venture is an outlier business: investors seek extreme strengths, not merely lack of weaknesses.</p>
+<h2 id="be-so-good-they-cannot-ignore-you">Be so good they cannot ignore you</h2>
+<p>Parker Conrad and Marc Andreessen converge on the same lesson: improving the business matters more than improving the pitch. If the business has clear momentum, investors come to it; if not, the pitch cannot compensate for weak underlying evidence.</p>
+<h2 id="onion-theory-of-risk">Onion theory of risk</h2>
+<p>Andreessen's fundraising model is to peel away layers of risk with each round. Seed capital should remove early team/product/launch risk; Series A should remove more product, recruiting, or customer risk; later rounds should map to specific milestones. Cash raised and cash spent should correspond to risks being removed.</p>
+<h2 id="practical-tactics">Practical tactics</h2>
+<ul>
+<li>Do not ask investors for NDAs.</li>
+<li>Get commitments and terms in writing immediately after meetings.</li>
+<li>Choose investors as long-term partners, closer to a marriage than a transaction.</li>
+<li>Terms matter less than investor quality, but excessive dilution can demotivate the team and block future rounds.</li>
+<li>Delay raising until the idea and initial promise are sufficiently clear when possible.</li>
+</ul>
+<h2 id="talking-to-investors-addendum">Talking to investors addendum</h2>
+<p>Lecture 19 adds a sales-like investor communication rule: make the story simple, direct, and milestone-based. Investors should quickly understand what the company does, why now, what progress proves it, and what risk the next financing removes. See <a href="../concepts/startup-sales-and-marketing.html">Startup Sales and Marketing</a>.</p>
+      </div>
+    </article>
+
+    <section class="wiki-related">
+      <h2>Related pages</h2>
+      <ul><li><a href="../concepts/startup-sales-and-marketing.html">Startup Sales and Marketing</a></li>
+<li><a href="../concepts/monopoly-theory.html">Monopoly Theory</a></li>
+<li><a href="../concepts/yc-how-to-start-a-startup.html">YC How to Start a Startup</a></li></ul>
+    </section>
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/concepts/startup-growth.html
+++ b/wiki/concepts/startup-growth.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Startup Growth · Jay Sosa Wiki</title>
+    <meta name="description" content="In the YC course, growth comes after product love. The strongest recurring claim is that retention is the foundation: if users do not stick, growth tactics only pour more users into a leaky bucket. alex-schultz...">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/concepts/startup-growth.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-concept">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Concept</p>
+      <h1>Startup Growth</h1>
+      <p class="meta">Concept · Updated 2026-05-28 · Confidence: high</p>
+      <div class="wiki-tags"><span>gtm</span><span>product</span><span>strategy</span></div>
+      <div class="wiki-content">
+<p>In the YC course, growth comes after product love. The strongest recurring claim is that retention is the foundation: if users do not stick, growth tactics only pour more users into a leaky bucket.</p>
+<h2 id="retention-first">Retention first</h2>
+<p><a href="../entities/alex-schultz.html">Alex Schultz</a> argues that retention is the single most important growth metric. A viable product has a retention curve that flattens above zero for some target segment. If the curve trends to zero, the company should fix product-market fit before hiring growth specialists or optimising virality.</p>
+<h2 id="north-star-and-magic-moment">North Star and magic moment</h2>
+<p>Growth needs a company-level North Star: Facebook used monthly active users; WhatsApp used sends; Airbnb used nights booked; eBay used gross merchandise volume. The North Star should make trade-offs obvious when founders are not in the room.</p>
+<p>The magic moment is the experience that makes the product's value click: seeing friends on Facebook, finding the unique item on eBay, or staying in a compelling Airbnb. Growth work should get users to that moment as fast as possible.</p>
+<h2 id="channels-and-tactics">Channels and tactics</h2>
+<p>Adora Cheung divides growth into:</p>
+<ul>
+<li><strong>Sticky growth:</strong> users return because the experience is good; measured via retention and CLV.</li>
+<li><strong>Viral growth:</strong> users tell or invite others; depends on product love and referral mechanics.</li>
+<li><strong>Paid growth:</strong> spend to acquire customers where CLV exceeds CAC and payback is sustainable.</li>
+</ul>
+<p>Alex Schultz adds tactical levers: virality, SEO, email/SMS/push notifications, internationalisation, and marginal-user optimisation. But he is explicit that these only work after retention exists.</p>
+<h2 id="founder-80-20-addendum">Founder 80/20 addendum</h2>
+<p><a href="../concepts/founder-80-20-principle.html">Founder 80/20 Principle</a> reinforces this page's retention-first frame: growth leverage is mostly retention over acquisition, word-of-mouth over paid ads, and friction reduction over incentives.</p>
+<h2 id="north-star-check-metrics-addendum">North Star check metrics addendum</h2>
+<p><a href="../entities/gokul-rajaram.html">Gokul Rajaram</a> adds that a North Star metric should indicate both customer value and company growth, but it must be paired with check metrics. Revenue alone is usually a poor North Star; better metrics describe useful customer behaviour, such as DAU, GPV, GMV, or volume of valuable work completed. Check metrics prevent the team from maximising the North Star by destroying margin, retention, trust, or customer health.</p>
+      </div>
+    </article>
+
+    <section class="wiki-related">
+      <h2>Related pages</h2>
+      <ul><li><a href="../entities/alex-schultz.html">Alex Schultz</a></li>
+<li><a href="../concepts/founder-80-20-principle.html">Founder 80/20 Principle</a></li>
+<li><a href="../entities/gokul-rajaram.html">Gokul Rajaram</a></li>
+<li><a href="../concepts/yc-how-to-start-a-startup.html">YC How to Start a Startup</a></li></ul>
+    </section>
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/concepts/startup-hiring-and-culture.html
+++ b/wiki/concepts/startup-hiring-and-culture.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Startup Hiring and Culture · Jay Sosa Wiki</title>
+    <meta name="description" content="Startup hiring is unusually high-leverage because the first few people set the culture, bar, and referral network for everyone after them. YC&#x27;s advice is to hire slowly at first, maintain a very high bar, and treat...">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/concepts/startup-hiring-and-culture.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-concept">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Concept</p>
+      <h1>Startup Hiring and Culture</h1>
+      <p class="meta">Concept · Updated 2026-05-28 · Confidence: high</p>
+      <div class="wiki-tags"><span>company</span><span>operator</span><span>strategy</span></div>
+      <div class="wiki-content">
+<p>Startup hiring is unusually high-leverage because the first few people set the culture, bar, and referral network for everyone after them. YC's advice is to hire slowly at first, maintain a very high bar, and treat early team decisions as company-defining.</p>
+<h2 id="cofounders-and-early-hires">Cofounders and early hires</h2>
+<ul>
+<li>Cofounder choice is one of the most important company decisions; random cofounder matching is dangerous.</li>
+<li>Two or three cofounders is often ideal; solo can work but is harder, and large founding teams are fragile.</li>
+<li>Early hires should be smart, get things done, and be people the founders want to spend time with.</li>
+<li>Personal referrals are the best source of candidates for the first hundred hires.</li>
+<li>Airbnb's early hiring bar is used as a benchmark: hire people who believe in the mission almost as much as the founders do.</li>
+</ul>
+<h2 id="culture-as-scalable-judgement">Culture as scalable judgement</h2>
+<p>The <a href="../entities/patrick-collison.html">Collison</a> framing is that culture solves a bandwidth problem: as the founders are involved in a shrinking fraction of decisions, culture preserves the invariant about how decisions should be made.</p>
+<p>Ben Silbermann frames culture as gardening: who you hire, what people do every day, what you communicate, and what you celebrate. Early employees should have low ego, high integrity, curiosity, creativity, and desire to build something larger than themselves.</p>
+<h2 id="retention-and-management">Retention and management</h2>
+<p>Founders must learn enough management to retain people: praise the team, give clear feedback, avoid micromanagement, and give increasing responsibility. Fire fast for persistent underperformance, politics, or corrosive negativity.</p>
+<h2 id="airbnb-and-alfred-lin-addendum">Airbnb and Alfred Lin addendum</h2>
+<p>Lecture 10 reinforces culture as founder-authored operating system. Alfred Lin stresses values as decision principles, not posters; Brian Chesky frames Airbnb's culture as the company DNA that had to survive scaling from family-like founding team into enduring company. This connects culture directly to <a href="../concepts/startup-management.html">Startup Management</a> and <a href="../concepts/later-stage-startup-scaling.html">Later-stage Startup Scaling</a>.</p>
+<h2 id="barrels-and-talent-addendum">Barrels and talent addendum</h2>
+<p><a href="../concepts/barrels-and-ammunition.html">Barrels and Ammunition</a> adds a hiring lens: teams need enough people who can autonomously own ambiguous problems from idea to shipped result. Hiring more talented contributors does not help if no one can aim and integrate their work.</p>
+      </div>
+    </article>
+
+    <section class="wiki-related">
+      <h2>Related pages</h2>
+      <ul><li><a href="../entities/patrick-collison.html">Patrick Collison</a></li>
+<li><a href="../concepts/startup-management.html">Startup Management</a></li>
+<li><a href="../concepts/later-stage-startup-scaling.html">Later-stage Startup Scaling</a></li>
+<li><a href="../concepts/barrels-and-ammunition.html">Barrels and Ammunition</a></li>
+<li><a href="../concepts/yc-how-to-start-a-startup.html">YC How to Start a Startup</a></li></ul>
+    </section>
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/concepts/startup-ideas-and-markets.html
+++ b/wiki/concepts/startup-ideas-and-markets.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Startup Ideas and Markets · Jay Sosa Wiki</title>
+    <meta name="description" content="A startup idea is not just the product. In YC&#x27;s framing, it includes the market, growth strategy, defensibility, timing, and why the company can become important. The idea should come before the startup: founders...">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/concepts/startup-ideas-and-markets.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-concept">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Concept</p>
+      <h1>Startup Ideas and Markets</h1>
+      <p class="meta">Concept · Updated 2026-05-28 · Confidence: high</p>
+      <div class="wiki-tags"><span>strategy</span><span>market</span><span>product</span></div>
+      <div class="wiki-content">
+<p>A startup idea is not just the product. In YC's framing, it includes the market, growth strategy, defensibility, timing, and why the company can become important. The idea should come before the startup: founders should wait for a problem they feel compelled to solve.</p>
+<h2 id="key-principles">Key principles</h2>
+<ul>
+<li><strong>Mission before company.</strong> Start a startup because a particular problem has to be solved, not because entrepreneurship seems glamorous.</li>
+<li><strong>Small wedge, large future.</strong> The first market can look tiny if it has a credible path to monopoly in a narrow niche and then expansion.</li>
+<li><strong>Why now?</strong> A strong idea has a clear answer to why this moment is uniquely right: technology, distribution, regulation, user behaviour, or market structure has changed.</li>
+<li><strong>Market tailwind beats static market size.</strong> A small but rapidly growing market is better than a large stagnant one. You can change many startup variables, but not whether a market exists.</li>
+<li><strong>Unpopular but right.</strong> Great ideas often sound bad because otherwise too many people would already be working on them.</li>
+<li><strong>Contrarian but not random.</strong> Per <a href="../entities/reid-hoffman.html">Reid Hoffman</a>, a real contrarian thesis explains what smart critics miss.</li>
+</ul>
+<h2 id="enterprise-version">Enterprise version</h2>
+<p>In <a href="../concepts/enterprise-software-startups.html">Enterprise Software Startups</a>, Aaron Levie reframes the same idea for B2B: look for technology discontinuities that create a gap between how work is done and how it could be done. Examples include cheaper cloud computing, mobile devices, better browsers, and industries needing new software because their own customers' expectations changed.</p>
+<h2 id="thiel-and-graham-addendum">Thiel and Graham addendum</h2>
+<p>Lecture 03 adds Paul Graham's warning against “playing house” and encourages founders to notice problems from inside the future. Lecture 05 adds Peter Thiel's monopoly lens: begin in a small market that can be dominated, then expand. See <a href="../concepts/startup-counterintuition.html">Startup Counterintuition</a> and <a href="../concepts/monopoly-theory.html">Monopoly Theory</a>.</p>
+<h2 id="defensibility-addendum">Defensibility addendum</h2>
+<p><a href="../concepts/software-moats.html">Software Moats</a> adds a durability test to market selection: a startup idea is stronger when the initial wedge can compound into multiple moats, not merely a product that can win early attention.</p>
+<h2 id="rabois-opportunity-formula-addendum">Rabois opportunity formula addendum</h2>
+<p><a href="../concepts/fragmented-industry-vertical-integration.html">Fragmented Industry Vertical Integration</a> adds a Rabois-style market pattern: large fragmented industry, low customer satisfaction, and a chance to vertically integrate a simpler product or experience. This is a practical complement to <a href="../concepts/monopoly-theory.html">Monopoly Theory</a> and <a href="../concepts/software-moats.html">Software Moats</a>.</p>
+      </div>
+    </article>
+
+    <section class="wiki-related">
+      <h2>Related pages</h2>
+      <ul><li><a href="../entities/reid-hoffman.html">Reid Hoffman</a></li>
+<li><a href="../concepts/enterprise-software-startups.html">Enterprise Software Startups</a></li>
+<li><a href="../concepts/startup-counterintuition.html">Startup Counterintuition</a></li>
+<li><a href="../concepts/monopoly-theory.html">Monopoly Theory</a></li>
+<li><a href="../concepts/software-moats.html">Software Moats</a></li>
+<li><a href="../concepts/fragmented-industry-vertical-integration.html">Fragmented Industry Vertical Integration</a></li>
+<li><a href="../concepts/yc-how-to-start-a-startup.html">YC How to Start a Startup</a></li></ul>
+    </section>
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/concepts/startup-legal-and-accounting.html
+++ b/wiki/concepts/startup-legal-and-accounting.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Startup Legal and Accounting · Jay Sosa Wiki</title>
+    <meta name="description" content="Kirsty Nathoo and Carolynn Levy&#x27;s lecture is about startup mechanics founders should understand enough to avoid expensive mistakes, without letting mechanics become the company-building focus. Legal/accounting basics...">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/concepts/startup-legal-and-accounting.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-concept">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Concept</p>
+      <h1>Startup Legal and Accounting</h1>
+      <p class="meta">Concept · Updated 2026-05-27 · Confidence: high</p>
+      <div class="wiki-tags"><span>company</span><span>operator</span><span>strategy</span></div>
+      <div class="wiki-content">
+<p>Kirsty Nathoo and Carolynn Levy's lecture is about startup mechanics founders should understand enough to avoid expensive mistakes, without letting mechanics become the company-building focus.</p>
+<h2 id="formation-and-paperwork">Formation and paperwork</h2>
+<ul>
+<li>Keep formation simple and standard; YC's default is a Delaware C-corporation because investors, lawyers, and employees understand it.</li>
+<li>Assign founder IP and inventions to the company.</li>
+<li>Keep signed documents organised and accessible.</li>
+<li>Avoid clever structures that create diligence problems later.</li>
+</ul>
+<h2 id="founder-equity">Founder equity</h2>
+<ul>
+<li>Execution matters more than the original idea.</li>
+<li>Equal or near-equal founder splits are often simplest when all founders are equally committed.</li>
+<li>Vesting protects the company if a founder leaves.</li>
+<li>Founders should make explicit decisions about roles, control, and long-term commitment early.</li>
+</ul>
+<h2 id="operating-hygiene">Operating hygiene</h2>
+<p>Legal/accounting basics also cover fundraising documents, employee vs contractor issues, option plans, payroll, taxes, bookkeeping, and board/investor records. The point is not to make founders amateur lawyers; it is to keep the company fundable and clean.</p>
+      </div>
+    </article>
+
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/concepts/startup-management.html
+++ b/wiki/concepts/startup-management.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Startup Management · Jay Sosa Wiki</title>
+    <meta name="description" content="Ben Horowitz&#x27;s management lecture centres on one hard rule: every management decision must be understood from the perspective of everyone affected, not only the person in the room. When making a critical decision,...">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/concepts/startup-management.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-concept">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Concept</p>
+      <h1>Startup Management</h1>
+      <p class="meta">Concept · Updated 2026-05-27 · Confidence: high</p>
+      <div class="wiki-tags"><span>operator</span><span>company</span><span>strategy</span></div>
+      <div class="wiki-content">
+<p>Ben Horowitz's management lecture centres on one hard rule: every management decision must be understood from the perspective of everyone affected, not only the person in the room.</p>
+<h2 id="main-principle">Main principle</h2>
+<p>When making a critical decision, the CEO must ask how it will be interpreted by:</p>
+<ul>
+<li>the individual employee;</li>
+<li>their peers;</li>
+<li>future employees in similar situations;</li>
+<li>managers who will copy the precedent;</li>
+<li>the broader culture.</li>
+</ul>
+<h2 id="cases-covered">Cases covered</h2>
+<ul>
+<li><strong>Demotion vs firing:</strong> a compassionate-seeming demotion can damage authority, equity fairness, and role clarity across the company.</li>
+<li><strong>Raises:</strong> granting ad hoc raises to those who ask creates a culture where everyone must negotiate constantly; formal processes can protect fairness and culture.</li>
+<li><strong>Performance and accountability:</strong> the CEO's decision teaches the company what behaviour is actually valued.</li>
+</ul>
+<h2 id="relationship-to-operating">Relationship to operating</h2>
+<p><a href="../concepts/startup-operating-and-management.html">Startup Operating and Management</a> focuses on building the machine; this page focuses on the cultural blast radius of management decisions. Together they argue that “process” is not always bureaucracy — sometimes it is how the company protects fairness, clarity, and speed.</p>
+      </div>
+    </article>
+
+    <section class="wiki-related">
+      <h2>Related pages</h2>
+      <ul><li><a href="../concepts/startup-operating-and-management.html">Startup Operating and Management</a></li>
+<li><a href="../concepts/startup-hiring-and-culture.html">Startup Hiring and Culture</a></li></ul>
+    </section>
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/concepts/startup-operating-and-management.html
+++ b/wiki/concepts/startup-operating-and-management.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Startup Operating and Management · Jay Sosa Wiki</title>
+    <meta name="description" content="Operating is the work of turning a product into a company. keith-rabois frames the company as an engine: early on it is held together with duct tape and heroics; the goal is eventually a high-performance machine that...">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/concepts/startup-operating-and-management.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-concept">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Concept</p>
+      <h1>Startup Operating and Management</h1>
+      <p class="meta">Concept · Updated 2026-05-28 · Confidence: high</p>
+      <div class="wiki-tags"><span>operator</span><span>company</span><span>strategy</span></div>
+      <div class="wiki-content">
+<p>Operating is the work of turning a product into a company. <a href="../entities/keith-rabois.html">Keith Rabois</a> frames the company as an engine: early on it is held together with duct tape and heroics; the goal is eventually a high-performance machine that can run without constant founder intervention.</p>
+<h2 id="editor-metaphor">Editor metaphor</h2>
+<p>The leader's job resembles an editor's job:</p>
+<ul>
+<li>simplify and clarify priorities;</li>
+<li>ask hard clarifying questions;</li>
+<li>allocate resources;</li>
+<li>ensure consistent voice;</li>
+<li>delegate without abdicating;</li>
+<li>edit the team.</li>
+</ul>
+<h2 id="delegation-and-judgement">Delegation and judgement</h2>
+<p>Delegation depends on task-relevant maturity: has this person done this exact task before? High maturity gets more rope; low maturity gets more instruction and monitoring. Decision rights should also depend on consequence and founder conviction: low-consequence/low-conviction decisions are good delegation opportunities, while high-consequence/high-conviction decisions need founder intervention with explanation.</p>
+<h2 id="barrels-and-ammunition">Barrels and ammunition</h2>
+<p>Rabois distinguishes barrels from ammunition. Barrels can take an idea from conception to shipping and bring people with them; ammunition are strong contributors who need a barrel to aim them. Hiring more people only increases output if the company has enough barrels.</p>
+<h2 id="management-mechanics">Management mechanics</h2>
+<ul>
+<li>Everyone should have one clear manager as the company scales.</li>
+<li>One-on-ones should happen roughly weekly or biweekly and be employee-led.</li>
+<li>Founders should audit calendars against stated priorities.</li>
+<li>Dashboards and paired metrics should help people make good decisions without founder involvement.</li>
+</ul>
+<h2 id="rabois-deep-research-addendum">Rabois deep research addendum</h2>
+<p>A later deep research source expands <a href="../entities/keith-rabois.html">Keith Rabois</a>'s operating doctrine into a broader system: priority ranking beats pros/cons lists, delegation should follow <a href="../concepts/conviction-consequence-delegation.html">Conviction-Consequence Delegation</a>, team scaling depends on <a href="../concepts/barrels-and-ammunition.html">Barrels and Ammunition</a>, and strong operating systems combine metrics, transparency, task-relevant maturity, and simplification. See <a href="../concepts/keith-rabois-operating-frameworks.html">Keith Rabois Operating Frameworks</a>.</p>
+<h2 id="ai-era-operating-addendum">AI-era operating addendum</h2>
+<p>The Chesky/Rajaram podcast ingests add an AI-era operating lens: managers need direct contact with craft and output, PMs need hands-on prototyping and eval judgement, and leaders should manage through the work rather than through layers of people-management abstraction. See <a href="../concepts/ai-founder-mode.html">AI Founder Mode</a>, <a href="../concepts/ai-era-product-management.html">AI-era Product Management</a>, and <a href="../concepts/operator-judgment-and-hiring.html">Operator Judgement and Hiring</a>.</p>
+      </div>
+    </article>
+
+    <section class="wiki-related">
+      <h2>Related pages</h2>
+      <ul><li><a href="../entities/keith-rabois.html">Keith Rabois</a></li>
+<li><a href="../concepts/conviction-consequence-delegation.html">Conviction-Consequence Delegation</a></li>
+<li><a href="../concepts/barrels-and-ammunition.html">Barrels and Ammunition</a></li>
+<li><a href="../concepts/keith-rabois-operating-frameworks.html">Keith Rabois Operating Frameworks</a></li>
+<li><a href="../concepts/ai-founder-mode.html">AI Founder Mode</a></li>
+<li><a href="../concepts/ai-era-product-management.html">AI-era Product Management</a></li>
+<li><a href="../concepts/operator-judgment-and-hiring.html">Operator Judgement and Hiring</a></li>
+<li><a href="../concepts/fragmented-industry-vertical-integration.html">Fragmented Industry Vertical Integration</a></li>
+<li><a href="../concepts/startup-management.html">Startup Management</a></li>
+<li><a href="../concepts/yc-how-to-start-a-startup.html">YC How to Start a Startup</a></li></ul>
+    </section>
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/concepts/startup-sales-and-marketing.html
+++ b/wiki/concepts/startup-sales-and-marketing.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Startup Sales and Marketing · Jay Sosa Wiki</title>
+    <meta name="description" content="Tyler Bosmeny&#x27;s sales lecture treats early sales as founder-led discovery and persistence, not a dark art performed by naturally charismatic salespeople. Early sales still has a funnel: prospecting, getting...">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/concepts/startup-sales-and-marketing.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-concept">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Concept</p>
+      <h1>Startup Sales and Marketing</h1>
+      <p class="meta">Concept · Updated 2026-05-27 · Confidence: high</p>
+      <div class="wiki-tags"><span>gtm</span><span>company</span><span>strategy</span></div>
+      <div class="wiki-content">
+<p>Tyler Bosmeny's sales lecture treats early sales as founder-led discovery and persistence, not a dark art performed by naturally charismatic salespeople.</p>
+<h2 id="sales-funnel-basics">Sales funnel basics</h2>
+<p>Early sales still has a funnel: prospecting, getting conversations, qualifying, following up, closing, and expanding. Founders have to build this first layer themselves because it teaches who cares and why.</p>
+<h2 id="practical-principles">Practical principles</h2>
+<ul>
+<li>Prospect for early adopters, not average customers.</li>
+<li>Use personal networks, conferences, and concise cold email.</li>
+<li>On calls, listen more than you talk.</li>
+<li>Follow up with unusually high persistence, but spend that effort on qualified prospects.</li>
+<li>Be careful with “one more feature” requests; convert them into commitments where possible.</li>
+<li>Avoid free trials that let prospects avoid a real buying decision.</li>
+</ul>
+<h2 id="talking-to-investors">Talking to investors</h2>
+<p>The lecture pairing with Michael Seibel reinforces <a href="../concepts/startup-fundraising.html">Startup Fundraising</a>: be clear, concise, traction-oriented, and direct about what the company does, why now, what progress exists, and what the next milestone is.</p>
+<h2 id="founder-80-20-addendum">Founder 80/20 addendum</h2>
+<p><a href="../concepts/founder-80-20-principle.html">Founder 80/20 Principle</a> adds a compact sales/GTM heuristic: sales is mostly listening over pitching, marketing is mostly word-of-mouth over paid ads, and market positioning is mostly owning a niche over broad appeal.</p>
+      </div>
+    </article>
+
+    <section class="wiki-related">
+      <h2>Related pages</h2>
+      <ul><li><a href="../concepts/startup-fundraising.html">Startup Fundraising</a></li>
+<li><a href="../concepts/founder-80-20-principle.html">Founder 80/20 Principle</a></li></ul>
+    </section>
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/concepts/startup-user-research.html
+++ b/wiki/concepts/startup-user-research.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Startup User Research · Jay Sosa Wiki</title>
+    <meta name="description" content="Startup user research is not a formal survey exercise. In the YC lectures, it means getting uncomfortably close to users, the industry, and the actual workflow before and during product building. Feedback quality...">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/concepts/startup-user-research.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-concept">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Concept</p>
+      <h1>Startup User Research</h1>
+      <p class="meta">Concept · Updated 2026-05-27 · Confidence: high</p>
+      <div class="wiki-tags"><span>product</span><span>research</span><span>strategy</span></div>
+      <div class="wiki-content">
+<p>Startup user research is not a formal survey exercise. In the YC lectures, it means getting uncomfortably close to users, the industry, and the actual workflow before and during product building.</p>
+<h2 id="adora-cheung-s-early-stage-method">Adora Cheung's early-stage method</h2>
+<ul>
+<li>State the problem in one sentence.</li>
+<li>Ask whether the founder personally has the problem or can get very close to those who do.</li>
+<li>Immerse in the industry; become a participant if necessary.</li>
+<li>Identify a narrow initial customer segment.</li>
+<li>Storyboard the full user experience from discovery to post-use feedback.</li>
+<li>Build the smallest viable product that solves the immediate problem.</li>
+<li>Talk to users directly, preferably in conversation rather than lab-like interrogation.</li>
+</ul>
+<h2 id="quality-of-feedback">Quality of feedback</h2>
+<p>Feedback quality varies by relationship and payment. Friends and family may be supportive but low-signal. Random users who paid are more likely to be brutally honest. Surveys mostly capture extremes; direct conversation reveals the middle.</p>
+<h2 id="manual-learning-beats-premature-automation">Manual learning beats premature automation</h2>
+<p>For Homejoy, manually cleaning homes and manually interviewing cleaners taught the team what needed to become software. Cheung's rule is to do manual work first, then automate once the team understands which steps predict quality or conversion.</p>
+<h2 id="emmett-shear-user-interview-addendum">Emmett Shear user interview addendum</h2>
+<p>Lecture 16 adds a more tactical interview method: choose a narrow user segment, find people who actually match it, ask about current behaviour rather than imagined preferences, and avoid selling the idea during the interview. This deepens the user-research side of <a href="../concepts/doing-things-that-do-not-scale.html">Doing Things That Do Not Scale</a> and <a href="../concepts/building-products-users-love.html">Building Products Users Love</a>.</p>
+      </div>
+    </article>
+
+    <section class="wiki-related">
+      <h2>Related pages</h2>
+      <ul><li><a href="../concepts/doing-things-that-do-not-scale.html">Doing Things That Do Not Scale</a></li>
+<li><a href="../concepts/building-products-users-love.html">Building Products Users Love</a></li>
+<li><a href="../concepts/founder-80-20-principle.html">Founder 80/20 Principle</a></li>
+<li><a href="../concepts/yc-how-to-start-a-startup.html">YC How to Start a Startup</a></li></ul>
+    </section>
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/concepts/thyroid-stress-hormones-and-energy-regulation.html
+++ b/wiki/concepts/thyroid-stress-hormones-and-energy-regulation.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Thyroid, Stress Hormones, and Energy Regulation · Jay Sosa Wiki</title>
+    <meta name="description" content="Deering&#x27;s framework treats thyroid function as the conductor of metabolism. T4 is the main thyroid output, T3 is framed as the more active hormone, and conversion depends partly on adequate liver glycogen, nutrition,...">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/concepts/thyroid-stress-hormones-and-energy-regulation.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-concept">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Concept</p>
+      <h1>Thyroid, Stress Hormones, and Energy Regulation</h1>
+      <p class="meta">Concept · Updated 2026-05-28 · Confidence: medium</p>
+      <div class="wiki-tags"><span>health</span><span>nutrition</span><span>metabolism</span></div>
+      <div class="wiki-content">
+<p>Deering's framework treats thyroid function as the conductor of metabolism. T4 is the main thyroid output, T3 is framed as the more active hormone, and conversion depends partly on adequate liver glycogen, nutrition, sleep, and low chronic stress.</p>
+<h2 id="core-model">Core model</h2>
+<ul>
+<li><strong>Thyroid = primary power system:</strong> supports heat, digestion, steroid hormone production, sleep, mood, and energy.</li>
+<li><strong>Adrenaline/cortisol = emergency generator:</strong> keeps blood sugar and performance going when fuel or recovery is inadequate.</li>
+<li><strong>Chronic stress = metabolic debt:</strong> persistent stress hormones can impair sleep, digestion, hormone production, and tissue repair.</li>
+</ul>
+<h2 id="deering-s-practical-implication">Deering's practical implication</h2>
+<p>Rather than pushing harder with fasting, more exercise, black coffee, or lower calories, the book recommends reducing stress load and improving fuel availability: carbohydrates, salt, dairy/minerals, adequate protein, saturated fats, sleep, and gentler movement.</p>
+<h2 id="caveat">Caveat</h2>
+<p>This is a thyroid-centred interpretation, not a full medical model. Thyroid symptoms overlap with many conditions, and “adrenal fatigue” terminology is contested. Clinical thyroid disease, diabetes, eating disorders, cardiovascular disease, pregnancy, or major symptoms require medical assessment.</p>
+      </div>
+    </article>
+
+    <section class="wiki-related">
+      <h2>Related pages</h2>
+      <ul><li><a href="../concepts/how-to-heal-your-metabolism.html">How to Heal Your Metabolism</a></li></ul>
+    </section>
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/concepts/yc-how-to-start-a-startup.html
+++ b/wiki/concepts/yc-how-to-start-a-startup.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>YC How to Start a Startup · Jay Sosa Wiki</title>
+    <meta name="description" content="Y Combinator&#x27;s How to Start a Startup is a startup/operator curriculum built around a simple thesis: hypergrowth startups require a great idea/market, a product users love, a strong team and culture, and relentless...">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/concepts/yc-how-to-start-a-startup.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-concept">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Concept</p>
+      <h1>YC How to Start a Startup</h1>
+      <p class="meta">Concept · Updated 2026-05-27 · Confidence: high</p>
+      <div class="wiki-tags"><span>company</span><span>strategy</span><span>product</span><span>operator</span><span>investing</span></div>
+      <div class="wiki-content">
+<p>Y Combinator's <em>How to Start a Startup</em> is a startup/operator curriculum built around a simple thesis: hypergrowth startups require a great <a href="../concepts/startup-ideas-and-markets.html">idea/market</a>, a <a href="../concepts/building-products-users-love.html">product users love</a>, a strong <a href="../concepts/startup-hiring-and-culture.html">team and culture</a>, and relentless <a href="../concepts/startup-execution-and-operating-rhythm.html">execution</a>. The course is explicitly aimed at companies that want to become very large; much of the advice is overpowered or inappropriate for normal companies.</p>
+<h2 id="core-synthesis">Core synthesis</h2>
+<ul>
+<li>Startups are multiplicative: idea × product × team × execution × luck. Weakness in one controllable area can kill the result.</li>
+<li>The early company should be almost monomaniacal: build product, talk to users, recruit the right few people, and maintain momentum.</li>
+<li>Good startup ideas often look bad initially because they start in a small or unfashionable market; the important question is whether the market has a fast-growing future and whether the founders have a non-obvious reason to be right.</li>
+<li>The founder's job changes over time: before product-market fit, build a great product; after product-market fit, build a great company.</li>
+<li>Fundraising, PR, management, HR, and process matter, but mostly after the product and market are working.</li>
+</ul>
+<h2 id="lecture-map-ingested">Lecture map ingested</h2>
+<ul>
+<li>Lecture 01: <a href="../concepts/startup-ideas-and-markets.html">Startup Ideas and Markets</a> and <a href="../concepts/building-products-users-love.html">Building Products Users Love</a>; Dustin Moskovitz on <a href="../concepts/founder-psychology-and-fit.html">Founder Psychology and Fit</a>.</li>
+<li>Lecture 02: <a href="../concepts/startup-hiring-and-culture.html">Startup Hiring and Culture</a> and <a href="../concepts/startup-execution-and-operating-rhythm.html">Startup Execution and Operating Rhythm</a>.</li>
+<li>Lecture 03: Paul Graham on counterintuitive startup ideas and founder intuition. Raw: <code>raw/transcripts/yc-how-to-start-a-startup-03-counterintuitive-parts-of-startups-and-how-to-have-ideas.md</code>.</li>
+<li>Lecture 04: <a href="../concepts/startup-user-research.html">Startup User Research</a> and early <a href="../concepts/startup-growth.html">Startup Growth</a>.</li>
+<li>Lecture 05: Peter Thiel on monopoly theory and business strategy. Raw: <code>raw/transcripts/yc-how-to-start-a-startup-05-business-strategy-and-monopoly-theory.md</code>.</li>
+<li>Lecture 06: <a href="../concepts/startup-growth.html">Startup Growth</a> and retention-led growth.</li>
+<li>Lecture 07: Kevin Hale on building products users love. Raw: <code>raw/transcripts/yc-how-to-start-a-startup-07-how-to-build-products-users-love.md</code>.</li>
+<li>Lecture 08: Walker Williams, Justin Kan, and Stanley Tang on doing things that do not scale, PR, and getting started. Raw: <code>raw/transcripts/yc-how-to-start-a-startup-08-doing-things-that-do-not-scale-pr-how-to-get-started.md</code>.</li>
+<li>Lecture 09: <a href="../concepts/startup-fundraising.html">Startup Fundraising</a>.</li>
+<li>Lecture 10: Brian Chesky and Alfred Lin on company culture and building a team. Raw: <code>raw/transcripts/yc-how-to-start-a-startup-10-company-culture-and-building-a-team-i.md</code>.</li>
+<li>Lecture 11: <a href="../concepts/startup-hiring-and-culture.html">Startup Hiring and Culture</a>, transparency, and early team design.</li>
+<li>Lecture 12: <a href="../concepts/enterprise-software-startups.html">Enterprise Software Startups</a>.</li>
+<li>Lecture 13: <a href="../concepts/founder-psychology-and-fit.html">Founder Psychology and Fit</a> and founder judgement.</li>
+<li>Lecture 14: <a href="../concepts/startup-operating-and-management.html">Startup Operating and Management</a>.</li>
+<li>Lecture 15: Ben Horowitz on management. Raw: <code>raw/transcripts/yc-how-to-start-a-startup-15-how-to-manage.md</code>.</li>
+<li>Lecture 16: Emmett Shear on user interviews. Raw: <code>raw/transcripts/yc-how-to-start-a-startup-16-how-to-run-a-user-interview.md</code>.</li>
+<li>Lecture 17: Hosain Rahman on hardware products. Raw: <code>raw/transcripts/yc-how-to-start-a-startup-17-how-to-design-hardware-products.md</code>.</li>
+<li>Lecture 18: Kirsty Nathoo and Carolynn Levy on legal and accounting basics. Raw: <code>raw/transcripts/yc-how-to-start-a-startup-18-legal-and-accounting-basics-for-startups.md</code>.</li>
+<li>Lecture 19: Tyler Bosmeny and Michael Seibel on sales, marketing, and talking to investors. Raw: <code>raw/transcripts/yc-how-to-start-a-startup-19-sales-and-marketing-how-to-talk-to-investors.md</code>.</li>
+<li>Lecture 20: <a href="../concepts/later-stage-startup-scaling.html">Later-stage Startup Scaling</a>.</li>
+</ul>
+<h2 id="why-it-matters-for-jay">Why it matters for Jay</h2>
+<p>This is a useful source set for product/operator judgement: market selection, customer obsession, GTM/growth loops, team design, capital strategy, and founder/CEO operating discipline. It should be treated as a set of mental models, not a rigid playbook.</p>
+      </div>
+    </article>
+
+    <section class="wiki-related">
+      <h2>Related pages</h2>
+      <ul><li><a href="../concepts/startup-ideas-and-markets.html">Startup Ideas and Markets</a></li>
+<li><a href="../concepts/building-products-users-love.html">Building Products Users Love</a></li>
+<li><a href="../concepts/startup-hiring-and-culture.html">Startup Hiring and Culture</a></li>
+<li><a href="../concepts/startup-execution-and-operating-rhythm.html">Startup Execution and Operating Rhythm</a></li>
+<li><a href="../concepts/founder-psychology-and-fit.html">Founder Psychology and Fit</a></li>
+<li><a href="../concepts/startup-user-research.html">Startup User Research</a></li>
+<li><a href="../concepts/startup-growth.html">Startup Growth</a></li>
+<li><a href="../concepts/startup-fundraising.html">Startup Fundraising</a></li>
+<li><a href="../concepts/enterprise-software-startups.html">Enterprise Software Startups</a></li>
+<li><a href="../concepts/startup-operating-and-management.html">Startup Operating and Management</a></li>
+<li><a href="../concepts/later-stage-startup-scaling.html">Later-stage Startup Scaling</a></li></ul>
+    </section>
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/entities/20vc.html
+++ b/wiki/entities/20vc.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>20VC · Jay Sosa Wiki</title>
+    <meta name="description" content="20VC is Harry Stebbings&#x27; podcast/source context for operator and investor frameworks. The wiki currently uses it for Gokul Rajaram&#x27;s eight-moats lens on enduring software companies and related AI-era...">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/entities/20vc.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-entity">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Entity</p>
+      <h1>20VC</h1>
+      <p class="meta">Entity · Updated 2026-05-28 · Confidence: medium</p>
+      <div class="wiki-tags"><span>company</span><span>investing</span><span>strategy</span></div>
+      <div class="wiki-content">
+<p>20VC is Harry Stebbings' podcast/source context for operator and investor frameworks. The wiki currently uses it for Gokul Rajaram's eight-moats lens on enduring software companies and related AI-era venture/business-model commentary.</p>
+      </div>
+    </article>
+
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/entities/aaron-levie.html
+++ b/wiki/entities/aaron-levie.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Aaron Levie · Jay Sosa Wiki</title>
+    <meta name="description" content="Aaron Levie is the Box cofounder and CEO whose lecture explains why cloud, mobile, and user-led adoption created a better era for enterprise software startups.">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/entities/aaron-levie.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-entity">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Entity</p>
+      <h1>Aaron Levie</h1>
+      <p class="meta">Entity · Updated 2026-05-27 · Confidence: high</p>
+      <div class="wiki-tags"><span>person</span><span>strategy</span></div>
+      <div class="wiki-content">
+<p>Aaron Levie is the Box cofounder and CEO whose lecture explains why cloud, mobile, and user-led adoption created a better era for enterprise software startups.</p>
+      </div>
+    </article>
+
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/entities/adora-cheung.html
+++ b/wiki/entities/adora-cheung.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Adora Cheung · Jay Sosa Wiki</title>
+    <meta name="description" content="Adora Cheung is the Homejoy founder whose lecture contributes practical lessons on industry immersion, manual user acquisition, MVPs, retention, and pivoting.">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/entities/adora-cheung.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-entity">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Entity</p>
+      <h1>Adora Cheung</h1>
+      <p class="meta">Entity · Updated 2026-05-27 · Confidence: high</p>
+      <div class="wiki-tags"><span>person</span><span>strategy</span></div>
+      <div class="wiki-content">
+<p>Adora Cheung is the Homejoy founder whose lecture contributes practical lessons on industry immersion, manual user acquisition, MVPs, retention, and pivoting.</p>
+      </div>
+    </article>
+
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/entities/alex-schultz.html
+++ b/wiki/entities/alex-schultz.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Alex Schultz · Jay Sosa Wiki</title>
+    <meta name="description" content="Alex Schultz is a Facebook growth leader whose lecture centres retention, North Star metrics, magic moments, marginal users, and growth channels.">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/entities/alex-schultz.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-entity">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Entity</p>
+      <h1>Alex Schultz</h1>
+      <p class="meta">Entity · Updated 2026-05-27 · Confidence: high</p>
+      <div class="wiki-tags"><span>person</span><span>strategy</span></div>
+      <div class="wiki-content">
+<p>Alex Schultz is a Facebook growth leader whose lecture centres retention, North Star metrics, magic moments, marginal users, and growth channels.</p>
+      </div>
+    </article>
+
+    <section class="wiki-related">
+      <h2>Related pages</h2>
+      <ul><li><a href="../concepts/startup-growth.html">Startup Growth</a></li></ul>
+    </section>
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/entities/alfred-lin.html
+++ b/wiki/entities/alfred-lin.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Alfred Lin · Jay Sosa Wiki</title>
+    <meta name="description" content="Alfred Lin is an operator/investor whose lecture section frames culture as explicit values, accountability, trust, conflict, and performance.">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/entities/alfred-lin.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-entity">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Entity</p>
+      <h1>Alfred Lin</h1>
+      <p class="meta">Entity · Updated 2026-05-27 · Confidence: high</p>
+      <div class="wiki-tags"><span>person</span><span>strategy</span></div>
+      <div class="wiki-content">
+<p>Alfred Lin is an operator/investor whose lecture section frames culture as explicit values, accountability, trust, conflict, and performance.</p>
+      </div>
+    </article>
+
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/entities/andrej-karpathy.html
+++ b/wiki/entities/andrej-karpathy.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Andrej Karpathy · Jay Sosa Wiki</title>
+    <meta name="description" content="Andrej Karpathy is the source author of the LLM Wiki idea ingested here. In this wiki, his relevance is as a useful AI practitioner whose note describes a practical pattern for using LLM agents to maintain a personal...">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/entities/andrej-karpathy.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-entity">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Entity</p>
+      <h1>Andrej Karpathy</h1>
+      <p class="meta">Entity · Updated 2026-05-27 · Confidence: medium</p>
+      <div class="wiki-tags"><span>person</span><span>ai</span><span>llm</span><span>research</span></div>
+      <div class="wiki-content">
+<p>Andrej Karpathy is the source author of the LLM Wiki idea ingested here. In this wiki, his relevance is as a useful AI practitioner whose note describes a practical pattern for using LLM agents to maintain a personal or team knowledge base.</p>
+<h2 id="relevant-idea">Relevant idea</h2>
+<p>Karpathy's note argues that a useful knowledge base should not only retrieve raw documents at query time. Instead, an LLM should incrementally maintain a compiled layer of markdown pages that captures synthesis, links, contradictions, and evolving understanding.</p>
+      </div>
+    </article>
+
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/entities/ben-horowitz.html
+++ b/wiki/entities/ben-horowitz.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Ben Horowitz · Jay Sosa Wiki</title>
+    <meta name="description" content="Ben Horowitz is an operator/investor whose management lecture focuses on interpreting decisions from every affected perspective and protecting culture through fair process.">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/entities/ben-horowitz.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-entity">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Entity</p>
+      <h1>Ben Horowitz</h1>
+      <p class="meta">Entity · Updated 2026-05-27 · Confidence: high</p>
+      <div class="wiki-tags"><span>person</span><span>strategy</span></div>
+      <div class="wiki-content">
+<p>Ben Horowitz is an operator/investor whose management lecture focuses on interpreting decisions from every affected perspective and protecting culture through fair process.</p>
+      </div>
+    </article>
+
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/entities/ben-silbermann.html
+++ b/wiki/entities/ben-silbermann.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Ben Silbermann · Jay Sosa Wiki</title>
+    <meta name="description" content="Ben Silbermann is the Pinterest founder whose lecture covers culture as hiring, daily behaviour, communication, celebration, and early user/customer obsession.">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/entities/ben-silbermann.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-entity">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Entity</p>
+      <h1>Ben Silbermann</h1>
+      <p class="meta">Entity · Updated 2026-05-27 · Confidence: high</p>
+      <div class="wiki-tags"><span>person</span><span>strategy</span></div>
+      <div class="wiki-content">
+<p>Ben Silbermann is the Pinterest founder whose lecture covers culture as hiring, daily behaviour, communication, celebration, and early user/customer obsession.</p>
+      </div>
+    </article>
+
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/entities/brian-chesky.html
+++ b/wiki/entities/brian-chesky.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Brian Chesky · Jay Sosa Wiki</title>
+    <meta name="description" content="Brian Chesky is Airbnb&#x27;s cofounder/CEO and a source for founder mode, product craft, culture, hiring, and consumer company building. In the YC corpus he explains culture as enduring company DNA. In the 2026 Invest...">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/entities/brian-chesky.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-entity">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Entity</p>
+      <h1>Brian Chesky</h1>
+      <p class="meta">Entity · Updated 2026-05-28 · Confidence: high</p>
+      <div class="wiki-tags"><span>person</span><span>strategy</span><span>operator</span><span>product</span><span>ai</span></div>
+      <div class="wiki-content">
+<p>Brian Chesky is Airbnb's cofounder/CEO and a source for founder mode, product craft, culture, hiring, and consumer company building. In the YC corpus he explains culture as enduring company DNA. In the 2026 Invest Like the Best interview he extends this into <a href="../concepts/ai-founder-mode.html">AI Founder Mode</a>: thinner layers, more direct contact with the work, and managers who remain close to craft.</p>
+<h2 id="key-mental-models">Key mental models</h2>
+<ul>
+<li><strong>Founder mode:</strong> start hands-on, learn the details, teach the right muscle memory, and give ground grudgingly.</li>
+<li><strong>AI founder mode:</strong> AI should reduce abstraction layers and make pure people management less defensible.</li>
+<li><strong>Project Hawaii:</strong> take a giant company, form a small elite team, make one problem tiny, and move crawl → walk → run → fly.</li>
+<li><strong>Eleven-star experience:</strong> imagine absurdly magical customer experiences, then industrialise the highest-value practical version.</li>
+<li><strong>Hiring as CEO work:</strong> pipeline recruit constantly; start with excellent work and trace backwards to the people behind it.</li>
+</ul>
+      </div>
+    </article>
+
+    <section class="wiki-related">
+      <h2>Related pages</h2>
+      <ul><li><a href="../concepts/ai-founder-mode.html">AI Founder Mode</a></li>
+<li><a href="../concepts/later-stage-startup-scaling.html">Later-stage Startup Scaling</a></li></ul>
+    </section>
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/entities/carolynn-levy.html
+++ b/wiki/entities/carolynn-levy.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Carolynn Levy · Jay Sosa Wiki</title>
+    <meta name="description" content="Carolynn Levy is a startup lawyer whose lecture covers legal formation, founder equity, IP assignment, documents, fundraising, and company hygiene.">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/entities/carolynn-levy.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-entity">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Entity</p>
+      <h1>Carolynn Levy</h1>
+      <p class="meta">Entity · Updated 2026-05-27 · Confidence: high</p>
+      <div class="wiki-tags"><span>person</span><span>strategy</span></div>
+      <div class="wiki-content">
+<p>Carolynn Levy is a startup lawyer whose lecture covers legal formation, founder equity, IP assignment, documents, fundraising, and company hygiene.</p>
+      </div>
+    </article>
+
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/entities/dustin-moskovitz.html
+++ b/wiki/entities/dustin-moskovitz.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Dustin Moskovitz · Jay Sosa Wiki</title>
+    <meta name="description" content="Dustin Moskovitz is a Facebook cofounder and Asana cofounder. In lecture 01 he argues the best reason to start a startup is that the founder cannot not do it and is uniquely suited to the problem.">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/entities/dustin-moskovitz.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-entity">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Entity</p>
+      <h1>Dustin Moskovitz</h1>
+      <p class="meta">Entity · Updated 2026-05-27 · Confidence: high</p>
+      <div class="wiki-tags"><span>person</span><span>strategy</span></div>
+      <div class="wiki-content">
+<p>Dustin Moskovitz is a Facebook cofounder and Asana cofounder. In lecture 01 he argues the best reason to start a startup is that the founder cannot not do it and is uniquely suited to the problem.</p>
+      </div>
+    </article>
+
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/entities/emmett-shear.html
+++ b/wiki/entities/emmett-shear.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Emmett Shear · Jay Sosa Wiki</title>
+    <meta name="description" content="Emmett Shear is a Twitch cofounder/CEO whose lecture explains how to run useful user interviews and how Twitch learned from broadcasters.">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/entities/emmett-shear.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-entity">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Entity</p>
+      <h1>Emmett Shear</h1>
+      <p class="meta">Entity · Updated 2026-05-27 · Confidence: high</p>
+      <div class="wiki-tags"><span>person</span><span>strategy</span></div>
+      <div class="wiki-content">
+<p>Emmett Shear is a Twitch cofounder/CEO whose lecture explains how to run useful user interviews and how Twitch learned from broadcasters.</p>
+      </div>
+    </article>
+
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/entities/gokul-rajaram.html
+++ b/wiki/entities/gokul-rajaram.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Gokul Rajaram · Jay Sosa Wiki</title>
+    <meta name="description" content="Gokul Rajaram is an operator/investor associated with Google, Facebook, Square, DoorDash, Coinbase, Pinterest, The Trade Desk, and Marathon. The wiki uses him as a source for software-moats, AI-era product...">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/entities/gokul-rajaram.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-entity">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Entity</p>
+      <h1>Gokul Rajaram</h1>
+      <p class="meta">Entity · Updated 2026-05-28 · Confidence: medium</p>
+      <div class="wiki-tags"><span>person</span><span>strategy</span><span>investing</span><span>product</span><span>ai</span></div>
+      <div class="wiki-content">
+<p>Gokul Rajaram is an operator/investor associated with Google, Facebook, Square, DoorDash, Coinbase, Pinterest, The Trade Desk, and Marathon. The wiki uses him as a source for <a href="../concepts/software-moats.html">Software Moats</a>, AI-era product management, ads businesses, North Star metrics, product-led self-serve, and work-project hiring.</p>
+<h2 id="key-mental-models">Key mental models</h2>
+<ul>
+<li><strong>Eight moats:</strong> data, workflow, regulatory, distribution, ecosystem, network, physical infrastructure, and scale.</li>
+<li><strong>AI-era PM:</strong> PMs guard the why, define customer-behaviour-change hypotheses, prototype hands-on, and own evals for non-deterministic software.</li>
+<li><strong>Outcome-based software:</strong> access products can keep seat pricing; work products should price around outputs or outcomes.</li>
+<li><strong>Full-stack vertical AI:</strong> one AI function in a vertical is rarely enough; the ambition should be to own the broader system.</li>
+<li><strong>Work projects:</strong> assess candidates by making them do realistic work and looking for agency, customer contact, and premise-questioning.</li>
+</ul>
+      </div>
+    </article>
+
+    <section class="wiki-related">
+      <h2>Related pages</h2>
+      <ul><li><a href="../concepts/software-moats.html">Software Moats</a></li>
+<li><a href="../concepts/enterprise-software-startups.html">Enterprise Software Startups</a></li>
+<li><a href="../concepts/startup-growth.html">Startup Growth</a></li></ul>
+    </section>
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/entities/greg-isenberg.html
+++ b/wiki/entities/greg-isenberg.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Greg Isenberg · Jay Sosa Wiki</title>
+    <meta name="description" content="Greg Isenberg is the author of the 20 Oct 2024 tweet ingested here on the &quot;80/20 principle&quot; for founders.">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/entities/greg-isenberg.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-entity">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Entity</p>
+      <h1>Greg Isenberg</h1>
+      <p class="meta">Entity · Updated 2026-05-27 · Confidence: medium</p>
+      <div class="wiki-tags"><span>person</span><span>strategy</span><span>gtm</span></div>
+      <div class="wiki-content">
+<p>Greg Isenberg is the author of the 20 Oct 2024 tweet ingested here on the "80/20 principle" for founders.</p>
+      </div>
+    </article>
+
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/entities/hosain-rahman.html
+++ b/wiki/entities/hosain-rahman.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Hosain Rahman · Jay Sosa Wiki</title>
+    <meta name="description" content="Hosain Rahman is the Jawbone founder whose lecture explains hardware product development as full-stack product, design, data, manufacturing, and brand work.">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/entities/hosain-rahman.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-entity">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Entity</p>
+      <h1>Hosain Rahman</h1>
+      <p class="meta">Entity · Updated 2026-05-27 · Confidence: high</p>
+      <div class="wiki-tags"><span>person</span><span>strategy</span></div>
+      <div class="wiki-content">
+<p>Hosain Rahman is the Jawbone founder whose lecture explains hardware product development as full-stack product, design, data, manufacturing, and brand work.</p>
+      </div>
+    </article>
+
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/entities/index.html
+++ b/wiki/entities/index.html
@@ -1,0 +1,173 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Entities · Jay Sosa Wiki</title>
+    <meta name="description" content="People, companies, products, institutions, and source contexts from Jay&#x27;s public wiki.">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-listing">
+    <header>
+      <h1>Entities</h1>
+      <p class="subtitle">35 pages</p>
+      <hr class="header-rule">
+    </header>
+    <section>
+      <h2>About</h2>
+      <p>People, companies, products, institutions, and source contexts from Jay&#x27;s public wiki.</p>
+      <p><a class="view-all" href="index.html">Wiki index</a></p>
+    </section>
+    <section>
+      <h2>Pages</h2>
+      <div class="wiki-card-list">
+        <a class="wiki-card" href="../entities/20vc.html">
+          <span class="wiki-card-title">20VC</span>
+          <span class="wiki-card-description">20VC is Harry Stebbings&#x27; podcast/source context for operator and investor frameworks. The wiki currently uses it for Gokul Rajaram&#x27;s eight-moats lens on enduring software companies and related AI-era...</span>
+        </a>
+        <a class="wiki-card" href="../entities/aaron-levie.html">
+          <span class="wiki-card-title">Aaron Levie</span>
+          <span class="wiki-card-description">Aaron Levie is the Box cofounder and CEO whose lecture explains why cloud, mobile, and user-led adoption created a better era for enterprise software startups.</span>
+        </a>
+        <a class="wiki-card" href="../entities/adora-cheung.html">
+          <span class="wiki-card-title">Adora Cheung</span>
+          <span class="wiki-card-description">Adora Cheung is the Homejoy founder whose lecture contributes practical lessons on industry immersion, manual user acquisition, MVPs, retention, and pivoting.</span>
+        </a>
+        <a class="wiki-card" href="../entities/alex-schultz.html">
+          <span class="wiki-card-title">Alex Schultz</span>
+          <span class="wiki-card-description">Alex Schultz is a Facebook growth leader whose lecture centres retention, North Star metrics, magic moments, marginal users, and growth channels.</span>
+        </a>
+        <a class="wiki-card" href="../entities/alfred-lin.html">
+          <span class="wiki-card-title">Alfred Lin</span>
+          <span class="wiki-card-description">Alfred Lin is an operator/investor whose lecture section frames culture as explicit values, accountability, trust, conflict, and performance.</span>
+        </a>
+        <a class="wiki-card" href="../entities/andrej-karpathy.html">
+          <span class="wiki-card-title">Andrej Karpathy</span>
+          <span class="wiki-card-description">Andrej Karpathy is the source author of the LLM Wiki idea ingested here. In this wiki, his relevance is as a useful AI practitioner whose note describes a practical pattern for using LLM agents to maintain a personal...</span>
+        </a>
+        <a class="wiki-card" href="../entities/ben-horowitz.html">
+          <span class="wiki-card-title">Ben Horowitz</span>
+          <span class="wiki-card-description">Ben Horowitz is an operator/investor whose management lecture focuses on interpreting decisions from every affected perspective and protecting culture through fair process.</span>
+        </a>
+        <a class="wiki-card" href="../entities/ben-silbermann.html">
+          <span class="wiki-card-title">Ben Silbermann</span>
+          <span class="wiki-card-description">Ben Silbermann is the Pinterest founder whose lecture covers culture as hiring, daily behaviour, communication, celebration, and early user/customer obsession.</span>
+        </a>
+        <a class="wiki-card" href="../entities/brian-chesky.html">
+          <span class="wiki-card-title">Brian Chesky</span>
+          <span class="wiki-card-description">Brian Chesky is Airbnb&#x27;s cofounder/CEO and a source for founder mode, product craft, culture, hiring, and consumer company building. In the YC corpus he explains culture as enduring company DNA. In the 2026 Invest...</span>
+        </a>
+        <a class="wiki-card" href="../entities/carolynn-levy.html">
+          <span class="wiki-card-title">Carolynn Levy</span>
+          <span class="wiki-card-description">Carolynn Levy is a startup lawyer whose lecture covers legal formation, founder equity, IP assignment, documents, fundraising, and company hygiene.</span>
+        </a>
+        <a class="wiki-card" href="../entities/dustin-moskovitz.html">
+          <span class="wiki-card-title">Dustin Moskovitz</span>
+          <span class="wiki-card-description">Dustin Moskovitz is a Facebook cofounder and Asana cofounder. In lecture 01 he argues the best reason to start a startup is that the founder cannot not do it and is uniquely suited to the problem.</span>
+        </a>
+        <a class="wiki-card" href="../entities/emmett-shear.html">
+          <span class="wiki-card-title">Emmett Shear</span>
+          <span class="wiki-card-description">Emmett Shear is a Twitch cofounder/CEO whose lecture explains how to run useful user interviews and how Twitch learned from broadcasters.</span>
+        </a>
+        <a class="wiki-card" href="../entities/gokul-rajaram.html">
+          <span class="wiki-card-title">Gokul Rajaram</span>
+          <span class="wiki-card-description">Gokul Rajaram is an operator/investor associated with Google, Facebook, Square, DoorDash, Coinbase, Pinterest, The Trade Desk, and Marathon. The wiki uses him as a source for software-moats, AI-era product...</span>
+        </a>
+        <a class="wiki-card" href="../entities/greg-isenberg.html">
+          <span class="wiki-card-title">Greg Isenberg</span>
+          <span class="wiki-card-description">Greg Isenberg is the author of the 20 Oct 2024 tweet ingested here on the &quot;80/20 principle&quot; for founders.</span>
+        </a>
+        <a class="wiki-card" href="../entities/hosain-rahman.html">
+          <span class="wiki-card-title">Hosain Rahman</span>
+          <span class="wiki-card-description">Hosain Rahman is the Jawbone founder whose lecture explains hardware product development as full-stack product, design, data, manufacturing, and brand work.</span>
+        </a>
+        <a class="wiki-card" href="../entities/invest-like-the-best.html">
+          <span class="wiki-card-title">Invest Like the Best</span>
+          <span class="wiki-card-description">Invest Like the Best is a Patrick O&#x27;Shaughnessy interview podcast used here as a source for founder/operator, product, investing, and AI-era company-building mental models.</span>
+        </a>
+        <a class="wiki-card" href="../entities/john-collison.html">
+          <span class="wiki-card-title">John Collison</span>
+          <span class="wiki-card-description">John Collison is a Stripe cofounder whose lecture stresses transparency, early hiring, fast onboarding, and feedback as cultural infrastructure.</span>
+        </a>
+        <a class="wiki-card" href="../entities/justin-kan.html">
+          <span class="wiki-card-title">Justin Kan</span>
+          <span class="wiki-card-description">Justin Kan is a founder speaker in the lecture on doing things that do not scale and a cofounder referenced in Emmett Shear’s user-interview lecture.</span>
+        </a>
+        <a class="wiki-card" href="../entities/kate-deering.html">
+          <span class="wiki-card-title">Kate Deering</span>
+          <span class="wiki-card-description">Kate Deering is the author of How to Heal Your Metabolism, a nutrition and lifestyle book in the Ray Peat/Broda Barnes-influenced tradition. In this wiki she is a source for metabolism-as-a-health-model,...</span>
+        </a>
+        <a class="wiki-card" href="../entities/keith-rabois.html">
+          <span class="wiki-card-title">Keith Rabois</span>
+          <span class="wiki-card-description">Keith Rabois is an operator/investor associated in this wiki with startup operating systems, talent frameworks, decision-making, and contrarian company-building. His YC lecture introduced the editor metaphor, barrels...</span>
+        </a>
+        <a class="wiki-card" href="../entities/kevin-hale.html">
+          <span class="wiki-card-title">Kevin Hale</span>
+          <span class="wiki-card-description">Kevin Hale is the Wufoo founder whose lecture translates “build something users love” into product craft, emotional detail, support, and user relationship design.</span>
+        </a>
+        <a class="wiki-card" href="../entities/kirsty-nathoo.html">
+          <span class="wiki-card-title">Kirsty Nathoo</span>
+          <span class="wiki-card-description">Kirsty Nathoo is a startup finance/accounting expert whose lecture covers startup formation, equity, records, accounting, taxes, and operating hygiene.</span>
+        </a>
+        <a class="wiki-card" href="../entities/marc-andreessen.html">
+          <span class="wiki-card-title">Marc Andreessen</span>
+          <span class="wiki-card-description">Marc Andreessen is a venture investor whose lecture frames venture as an outlier business, investing in strength rather than lack of weakness, and using rounds to remove layers of risk.</span>
+        </a>
+        <a class="wiki-card" href="../entities/michael-seibel.html">
+          <span class="wiki-card-title">Michael Seibel</span>
+          <span class="wiki-card-description">Michael Seibel is a YC partner/founder speaker in lecture 19 on talking to investors and communicating startup progress clearly.</span>
+        </a>
+        <a class="wiki-card" href="../entities/parker-conrad.html">
+          <span class="wiki-card-title">Parker Conrad</span>
+          <span class="wiki-card-description">Parker Conrad is the Zenefits founder whose fundraising lesson is that the easiest money comes when the underlying business is clearly working.</span>
+        </a>
+        <a class="wiki-card" href="../entities/patrick-collison.html">
+          <span class="wiki-card-title">Patrick Collison</span>
+          <span class="wiki-card-description">Patrick Collison is a Stripe cofounder whose lecture frames culture as the invariant that scales when founders can no longer be in every decision.</span>
+        </a>
+        <a class="wiki-card" href="../entities/paul-graham.html">
+          <span class="wiki-card-title">Paul Graham</span>
+          <span class="wiki-card-description">Paul Graham is a YC founder and essayist whose lecture explains why startups are counterintuitive, why “playing house” is dangerous, and how founders should think about ideas.</span>
+        </a>
+        <a class="wiki-card" href="../entities/peter-thiel.html">
+          <span class="wiki-card-title">Peter Thiel</span>
+          <span class="wiki-card-description">Peter Thiel is a PayPal and Palantir cofounder and investor whose lecture argues startups should aim for monopoly rather than competition.</span>
+        </a>
+        <a class="wiki-card" href="../entities/reid-hoffman.html">
+          <span class="wiki-card-title">Reid Hoffman</span>
+          <span class="wiki-card-description">Reid Hoffman is the LinkedIn founder and investor whose lecture analyses founder judgement, contrarian theses, networks, risk, persistence, and adaptation.</span>
+        </a>
+        <a class="wiki-card" href="../entities/ron-conway.html">
+          <span class="wiki-card-title">Ron Conway</span>
+          <span class="wiki-card-description">Ron Conway is an angel investor whose fundraising advice emphasises founder leadership, communication, product obsession, decisiveness, trust, and getting commitments in writing.</span>
+        </a>
+        <a class="wiki-card" href="../entities/sam-altman.html">
+          <span class="wiki-card-title">Sam Altman</span>
+          <span class="wiki-card-description">Sam Altman is a YC leader and recurring lecturer in this source set. His lectures provide the course spine: ideas, products, teams, execution, and later-stage scaling.</span>
+        </a>
+        <a class="wiki-card" href="../entities/stanley-tang.html">
+          <span class="wiki-card-title">Stanley Tang</span>
+          <span class="wiki-card-description">Stanley Tang is a DoorDash cofounder whose lecture section gives a concrete example of launching fast and doing manual work before scaling.</span>
+        </a>
+        <a class="wiki-card" href="../entities/tyler-bosmeny.html">
+          <span class="wiki-card-title">Tyler Bosmeny</span>
+          <span class="wiki-card-description">Tyler Bosmeny is the Clever founder whose lecture explains early startup sales as founder-led prospecting, listening, follow-up, closing, and qualification.</span>
+        </a>
+        <a class="wiki-card" href="../entities/walker-williams.html">
+          <span class="wiki-card-title">Walker Williams</span>
+          <span class="wiki-card-description">Walker Williams is a founder speaker in the lecture on doing things that do not scale, PR, and getting started.</span>
+        </a>
+        <a class="wiki-card" href="../entities/y-combinator.html">
+          <span class="wiki-card-title">Y Combinator</span>
+          <span class="wiki-card-description">Y Combinator is the startup accelerator behind the How to Start a Startup lecture series. In this wiki, it is a source of founder/operator mental models rather than a general company profile.</span>
+        </a>
+      </div>
+    </section>
+    <footer>
+      <span>© 2026 Jeison Sosa</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/entities/invest-like-the-best.html
+++ b/wiki/entities/invest-like-the-best.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Invest Like the Best · Jay Sosa Wiki</title>
+    <meta name="description" content="Invest Like the Best is a Patrick O&#x27;Shaughnessy interview podcast used here as a source for founder/operator, product, investing, and AI-era company-building mental models.">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/entities/invest-like-the-best.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-entity">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Entity</p>
+      <h1>Invest Like the Best</h1>
+      <p class="meta">Entity · Updated 2026-05-28 · Confidence: medium</p>
+      <div class="wiki-tags"><span>research</span><span>investing</span><span>operator</span></div>
+      <div class="wiki-content">
+<p>Invest Like the Best is a Patrick O'Shaughnessy interview podcast used here as a source for founder/operator, product, investing, and AI-era company-building mental models.</p>
+<h2 id="ingested-episodes">Ingested episodes</h2>
+<ul>
+<li>Brian Chesky on AI founder mode, industrial design, Airbnb's Project Hawaii, the eleven-star experience, hiring, and creation for intrinsic motivation.</li>
+<li>Gokul Rajaram on AI-era product management, judgement, durable software, ads, North Star metrics, self-serve product, work projects, and founder authenticity.</li>
+</ul>
+      </div>
+    </article>
+
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/entities/john-collison.html
+++ b/wiki/entities/john-collison.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>John Collison · Jay Sosa Wiki</title>
+    <meta name="description" content="John Collison is a Stripe cofounder whose lecture stresses transparency, early hiring, fast onboarding, and feedback as cultural infrastructure.">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/entities/john-collison.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-entity">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Entity</p>
+      <h1>John Collison</h1>
+      <p class="meta">Entity · Updated 2026-05-27 · Confidence: high</p>
+      <div class="wiki-tags"><span>person</span><span>strategy</span></div>
+      <div class="wiki-content">
+<p>John Collison is a Stripe cofounder whose lecture stresses transparency, early hiring, fast onboarding, and feedback as cultural infrastructure.</p>
+      </div>
+    </article>
+
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/entities/justin-kan.html
+++ b/wiki/entities/justin-kan.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Justin Kan · Jay Sosa Wiki</title>
+    <meta name="description" content="Justin Kan is a founder speaker in the lecture on doing things that do not scale and a cofounder referenced in Emmett Shear’s user-interview lecture.">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/entities/justin-kan.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-entity">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Entity</p>
+      <h1>Justin Kan</h1>
+      <p class="meta">Entity · Updated 2026-05-27 · Confidence: high</p>
+      <div class="wiki-tags"><span>person</span><span>strategy</span></div>
+      <div class="wiki-content">
+<p>Justin Kan is a founder speaker in the lecture on doing things that do not scale and a cofounder referenced in Emmett Shear’s user-interview lecture.</p>
+      </div>
+    </article>
+
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/entities/kate-deering.html
+++ b/wiki/entities/kate-deering.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Kate Deering · Jay Sosa Wiki</title>
+    <meta name="description" content="Kate Deering is the author of How to Heal Your Metabolism, a nutrition and lifestyle book in the Ray Peat/Broda Barnes-influenced tradition. In this wiki she is a source for metabolism-as-a-health-model,...">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/entities/kate-deering.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-entity">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Entity</p>
+      <h1>Kate Deering</h1>
+      <p class="meta">Entity · Updated 2026-05-28 · Confidence: medium</p>
+      <div class="wiki-tags"><span>person</span><span>health</span><span>nutrition</span><span>metabolism</span></div>
+      <div class="wiki-content">
+<p>Kate Deering is the author of <em>How to Heal Your Metabolism</em>, a nutrition and lifestyle book in the Ray Peat/Broda Barnes-influenced tradition. In this wiki she is a source for <a href="../concepts/metabolism-as-a-health-model.html">Metabolism as a Health Model</a>, <a href="../concepts/pro-metabolic-nutrition.html">Pro-Metabolic Nutrition</a>, <a href="../concepts/pufa-avoidance.html">PUFA Avoidance</a>, and the use of body temperature, pulse, digestion, sleep, mood, and food tolerance as practical metabolic feedback.</p>
+<h2 id="core-position">Core position</h2>
+<p>Deering frames health as a high-energy state: warm body temperature, steady pulse, good sleep, regular bowel movements, stable mood, libido, fertility, digestion, immunity, and resilient body composition. The book argues that chronic dieting, low carbohydrate intake, excessive exercise, poor sleep, stress, under-fuelling, industrial seed oils, and difficult-to-digest foods suppress metabolism and push the body towards stress-hormone compensation.</p>
+<h2 id="caveat">Caveat</h2>
+<p>Many of Deering's claims are explicitly outside mainstream consensus, especially around saturated fat, PUFA avoidance, fruit juice/sugar, raw milk, salt, and thyroid-centred self-monitoring. Treat her framework as a coherent nutrition model to compare and test, not as medical advice. See <a href="../concepts/contested-nutrition-claims-kate-deering.html">Contested Nutrition Claims — Kate Deering</a>.</p>
+      </div>
+    </article>
+
+    <section class="wiki-related">
+      <h2>Related pages</h2>
+      <ul><li><a href="../concepts/metabolism-as-a-health-model.html">Metabolism as a Health Model</a></li>
+<li><a href="../concepts/pro-metabolic-nutrition.html">Pro-Metabolic Nutrition</a></li>
+<li><a href="../concepts/pufa-avoidance.html">PUFA Avoidance</a></li>
+<li><a href="../concepts/contested-nutrition-claims-kate-deering.html">Contested Nutrition Claims — Kate Deering</a></li>
+<li><a href="../concepts/how-to-heal-your-metabolism.html">How to Heal Your Metabolism</a></li></ul>
+    </section>
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/entities/keith-rabois.html
+++ b/wiki/entities/keith-rabois.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Keith Rabois · Jay Sosa Wiki</title>
+    <meta name="description" content="Keith Rabois is an operator/investor associated in this wiki with startup operating systems, talent frameworks, decision-making, and contrarian company-building. His YC lecture introduced the editor metaphor, barrels...">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/entities/keith-rabois.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-entity">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Entity</p>
+      <h1>Keith Rabois</h1>
+      <p class="meta">Entity · Updated 2026-05-28 · Confidence: medium</p>
+      <div class="wiki-tags"><span>person</span><span>strategy</span><span>operator</span><span>investing</span></div>
+      <div class="wiki-content">
+<p>Keith Rabois is an operator/investor associated in this wiki with startup operating systems, talent frameworks, decision-making, and contrarian company-building. His YC lecture introduced the editor metaphor, barrels and ammunition, dashboards, transparency, details, and management cadence. A later user-provided deep research report broadens the page into his public framework corpus.</p>
+<h2 id="key-frameworks">Key frameworks</h2>
+<ul>
+<li><a href="../concepts/keith-rabois-operating-frameworks.html">Keith Rabois Operating Frameworks</a> — hub for the broader Rabois framework set.</li>
+<li><a href="../concepts/conviction-consequence-delegation.html">Conviction-Consequence Delegation</a> — decide delegation depth by consequence and founder conviction.</li>
+<li><a href="../concepts/barrels-and-ammunition.html">Barrels and Ammunition</a> — distinguish autonomous owners from high-quality contributors who need direction.</li>
+<li><a href="../concepts/fragmented-industry-vertical-integration.html">Fragmented Industry Vertical Integration</a> — startup opportunity pattern: large fragmented low-NPS industry plus integrated solution.</li>
+<li><a href="../concepts/startup-operating-and-management.html">Startup Operating and Management</a> — Rabois's operating lecture synthesis.</li>
+</ul>
+      </div>
+    </article>
+
+    <section class="wiki-related">
+      <h2>Related pages</h2>
+      <ul><li><a href="../concepts/keith-rabois-operating-frameworks.html">Keith Rabois Operating Frameworks</a></li>
+<li><a href="../concepts/conviction-consequence-delegation.html">Conviction-Consequence Delegation</a></li>
+<li><a href="../concepts/barrels-and-ammunition.html">Barrels and Ammunition</a></li>
+<li><a href="../concepts/fragmented-industry-vertical-integration.html">Fragmented Industry Vertical Integration</a></li>
+<li><a href="../concepts/startup-operating-and-management.html">Startup Operating and Management</a></li>
+<li><a href="../concepts/building-products-users-love.html">Building Products Users Love</a></li>
+<li><a href="../concepts/startup-execution-and-operating-rhythm.html">Startup Execution and Operating Rhythm</a></li></ul>
+    </section>
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/entities/kevin-hale.html
+++ b/wiki/entities/kevin-hale.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Kevin Hale · Jay Sosa Wiki</title>
+    <meta name="description" content="Kevin Hale is the Wufoo founder whose lecture translates “build something users love” into product craft, emotional detail, support, and user relationship design.">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/entities/kevin-hale.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-entity">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Entity</p>
+      <h1>Kevin Hale</h1>
+      <p class="meta">Entity · Updated 2026-05-27 · Confidence: high</p>
+      <div class="wiki-tags"><span>person</span><span>strategy</span></div>
+      <div class="wiki-content">
+<p>Kevin Hale is the Wufoo founder whose lecture translates “build something users love” into product craft, emotional detail, support, and user relationship design.</p>
+      </div>
+    </article>
+
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/entities/kirsty-nathoo.html
+++ b/wiki/entities/kirsty-nathoo.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Kirsty Nathoo · Jay Sosa Wiki</title>
+    <meta name="description" content="Kirsty Nathoo is a startup finance/accounting expert whose lecture covers startup formation, equity, records, accounting, taxes, and operating hygiene.">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/entities/kirsty-nathoo.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-entity">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Entity</p>
+      <h1>Kirsty Nathoo</h1>
+      <p class="meta">Entity · Updated 2026-05-27 · Confidence: high</p>
+      <div class="wiki-tags"><span>person</span><span>strategy</span></div>
+      <div class="wiki-content">
+<p>Kirsty Nathoo is a startup finance/accounting expert whose lecture covers startup formation, equity, records, accounting, taxes, and operating hygiene.</p>
+      </div>
+    </article>
+
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/entities/marc-andreessen.html
+++ b/wiki/entities/marc-andreessen.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Marc Andreessen · Jay Sosa Wiki</title>
+    <meta name="description" content="Marc Andreessen is a venture investor whose lecture frames venture as an outlier business, investing in strength rather than lack of weakness, and using rounds to remove layers of risk.">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/entities/marc-andreessen.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-entity">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Entity</p>
+      <h1>Marc Andreessen</h1>
+      <p class="meta">Entity · Updated 2026-05-27 · Confidence: high</p>
+      <div class="wiki-tags"><span>person</span><span>strategy</span></div>
+      <div class="wiki-content">
+<p>Marc Andreessen is a venture investor whose lecture frames venture as an outlier business, investing in strength rather than lack of weakness, and using rounds to remove layers of risk.</p>
+      </div>
+    </article>
+
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/entities/michael-seibel.html
+++ b/wiki/entities/michael-seibel.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Michael Seibel · Jay Sosa Wiki</title>
+    <meta name="description" content="Michael Seibel is a YC partner/founder speaker in lecture 19 on talking to investors and communicating startup progress clearly.">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/entities/michael-seibel.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-entity">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Entity</p>
+      <h1>Michael Seibel</h1>
+      <p class="meta">Entity · Updated 2026-05-27 · Confidence: high</p>
+      <div class="wiki-tags"><span>person</span><span>strategy</span></div>
+      <div class="wiki-content">
+<p>Michael Seibel is a YC partner/founder speaker in lecture 19 on talking to investors and communicating startup progress clearly.</p>
+      </div>
+    </article>
+
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/entities/parker-conrad.html
+++ b/wiki/entities/parker-conrad.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Parker Conrad · Jay Sosa Wiki</title>
+    <meta name="description" content="Parker Conrad is the Zenefits founder whose fundraising lesson is that the easiest money comes when the underlying business is clearly working.">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/entities/parker-conrad.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-entity">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Entity</p>
+      <h1>Parker Conrad</h1>
+      <p class="meta">Entity · Updated 2026-05-27 · Confidence: high</p>
+      <div class="wiki-tags"><span>person</span><span>strategy</span></div>
+      <div class="wiki-content">
+<p>Parker Conrad is the Zenefits founder whose fundraising lesson is that the easiest money comes when the underlying business is clearly working.</p>
+      </div>
+    </article>
+
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/entities/patrick-collison.html
+++ b/wiki/entities/patrick-collison.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Patrick Collison · Jay Sosa Wiki</title>
+    <meta name="description" content="Patrick Collison is a Stripe cofounder whose lecture frames culture as the invariant that scales when founders can no longer be in every decision.">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/entities/patrick-collison.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-entity">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Entity</p>
+      <h1>Patrick Collison</h1>
+      <p class="meta">Entity · Updated 2026-05-27 · Confidence: high</p>
+      <div class="wiki-tags"><span>person</span><span>strategy</span></div>
+      <div class="wiki-content">
+<p>Patrick Collison is a Stripe cofounder whose lecture frames culture as the invariant that scales when founders can no longer be in every decision.</p>
+      </div>
+    </article>
+
+    <section class="wiki-related">
+      <h2>Related pages</h2>
+      <ul><li><a href="../concepts/startup-hiring-and-culture.html">Startup Hiring and Culture</a></li></ul>
+    </section>
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/entities/paul-graham.html
+++ b/wiki/entities/paul-graham.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Paul Graham · Jay Sosa Wiki</title>
+    <meta name="description" content="Paul Graham is a YC founder and essayist whose lecture explains why startups are counterintuitive, why “playing house” is dangerous, and how founders should think about ideas.">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/entities/paul-graham.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-entity">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Entity</p>
+      <h1>Paul Graham</h1>
+      <p class="meta">Entity · Updated 2026-05-27 · Confidence: high</p>
+      <div class="wiki-tags"><span>person</span><span>strategy</span></div>
+      <div class="wiki-content">
+<p>Paul Graham is a YC founder and essayist whose lecture explains why startups are counterintuitive, why “playing house” is dangerous, and how founders should think about ideas.</p>
+      </div>
+    </article>
+
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/entities/peter-thiel.html
+++ b/wiki/entities/peter-thiel.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Peter Thiel · Jay Sosa Wiki</title>
+    <meta name="description" content="Peter Thiel is a PayPal and Palantir cofounder and investor whose lecture argues startups should aim for monopoly rather than competition.">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/entities/peter-thiel.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-entity">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Entity</p>
+      <h1>Peter Thiel</h1>
+      <p class="meta">Entity · Updated 2026-05-27 · Confidence: high</p>
+      <div class="wiki-tags"><span>person</span><span>strategy</span></div>
+      <div class="wiki-content">
+<p>Peter Thiel is a PayPal and Palantir cofounder and investor whose lecture argues startups should aim for monopoly rather than competition.</p>
+      </div>
+    </article>
+
+    <section class="wiki-related">
+      <h2>Related pages</h2>
+      <ul><li><a href="../concepts/conviction-consequence-delegation.html">Conviction-Consequence Delegation</a></li></ul>
+    </section>
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/entities/reid-hoffman.html
+++ b/wiki/entities/reid-hoffman.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Reid Hoffman · Jay Sosa Wiki</title>
+    <meta name="description" content="Reid Hoffman is the LinkedIn founder and investor whose lecture analyses founder judgement, contrarian theses, networks, risk, persistence, and adaptation.">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/entities/reid-hoffman.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-entity">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Entity</p>
+      <h1>Reid Hoffman</h1>
+      <p class="meta">Entity · Updated 2026-05-27 · Confidence: high</p>
+      <div class="wiki-tags"><span>person</span><span>strategy</span></div>
+      <div class="wiki-content">
+<p>Reid Hoffman is the LinkedIn founder and investor whose lecture analyses founder judgement, contrarian theses, networks, risk, persistence, and adaptation.</p>
+      </div>
+    </article>
+
+    <section class="wiki-related">
+      <h2>Related pages</h2>
+      <ul><li><a href="../concepts/founder-psychology-and-fit.html">Founder Psychology and Fit</a></li>
+<li><a href="../concepts/startup-ideas-and-markets.html">Startup Ideas and Markets</a></li></ul>
+    </section>
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/entities/ron-conway.html
+++ b/wiki/entities/ron-conway.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Ron Conway · Jay Sosa Wiki</title>
+    <meta name="description" content="Ron Conway is an angel investor whose fundraising advice emphasises founder leadership, communication, product obsession, decisiveness, trust, and getting commitments in writing.">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/entities/ron-conway.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-entity">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Entity</p>
+      <h1>Ron Conway</h1>
+      <p class="meta">Entity · Updated 2026-05-27 · Confidence: high</p>
+      <div class="wiki-tags"><span>person</span><span>strategy</span></div>
+      <div class="wiki-content">
+<p>Ron Conway is an angel investor whose fundraising advice emphasises founder leadership, communication, product obsession, decisiveness, trust, and getting commitments in writing.</p>
+      </div>
+    </article>
+
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/entities/sam-altman.html
+++ b/wiki/entities/sam-altman.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Sam Altman · Jay Sosa Wiki</title>
+    <meta name="description" content="Sam Altman is a YC leader and recurring lecturer in this source set. His lectures provide the course spine: ideas, products, teams, execution, and later-stage scaling.">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/entities/sam-altman.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-entity">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Entity</p>
+      <h1>Sam Altman</h1>
+      <p class="meta">Entity · Updated 2026-05-27 · Confidence: high</p>
+      <div class="wiki-tags"><span>person</span><span>strategy</span></div>
+      <div class="wiki-content">
+<p>Sam Altman is a YC leader and recurring lecturer in this source set. His lectures provide the course spine: ideas, products, teams, execution, and later-stage scaling.</p>
+      </div>
+    </article>
+
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/entities/stanley-tang.html
+++ b/wiki/entities/stanley-tang.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Stanley Tang · Jay Sosa Wiki</title>
+    <meta name="description" content="Stanley Tang is a DoorDash cofounder whose lecture section gives a concrete example of launching fast and doing manual work before scaling.">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/entities/stanley-tang.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-entity">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Entity</p>
+      <h1>Stanley Tang</h1>
+      <p class="meta">Entity · Updated 2026-05-27 · Confidence: high</p>
+      <div class="wiki-tags"><span>person</span><span>strategy</span></div>
+      <div class="wiki-content">
+<p>Stanley Tang is a DoorDash cofounder whose lecture section gives a concrete example of launching fast and doing manual work before scaling.</p>
+      </div>
+    </article>
+
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/entities/tyler-bosmeny.html
+++ b/wiki/entities/tyler-bosmeny.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Tyler Bosmeny · Jay Sosa Wiki</title>
+    <meta name="description" content="Tyler Bosmeny is the Clever founder whose lecture explains early startup sales as founder-led prospecting, listening, follow-up, closing, and qualification.">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/entities/tyler-bosmeny.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-entity">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Entity</p>
+      <h1>Tyler Bosmeny</h1>
+      <p class="meta">Entity · Updated 2026-05-27 · Confidence: high</p>
+      <div class="wiki-tags"><span>person</span><span>strategy</span></div>
+      <div class="wiki-content">
+<p>Tyler Bosmeny is the Clever founder whose lecture explains early startup sales as founder-led prospecting, listening, follow-up, closing, and qualification.</p>
+      </div>
+    </article>
+
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/entities/walker-williams.html
+++ b/wiki/entities/walker-williams.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Walker Williams · Jay Sosa Wiki</title>
+    <meta name="description" content="Walker Williams is a founder speaker in the lecture on doing things that do not scale, PR, and getting started.">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/entities/walker-williams.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-entity">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Entity</p>
+      <h1>Walker Williams</h1>
+      <p class="meta">Entity · Updated 2026-05-27 · Confidence: high</p>
+      <div class="wiki-tags"><span>person</span><span>strategy</span></div>
+      <div class="wiki-content">
+<p>Walker Williams is a founder speaker in the lecture on doing things that do not scale, PR, and getting started.</p>
+      </div>
+    </article>
+
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/entities/y-combinator.html
+++ b/wiki/entities/y-combinator.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Y Combinator · Jay Sosa Wiki</title>
+    <meta name="description" content="Y Combinator is the startup accelerator behind the How to Start a Startup lecture series. In this wiki, it is a source of founder/operator mental models rather than a general company profile.">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/entities/y-combinator.html">
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="../wiki.css">
+  </head>
+  <body class="wiki-page wiki-entity">
+    <a class="back-link" href="../index.html">← Wiki index</a>
+    <article>
+      <p class="ref">Entity</p>
+      <h1>Y Combinator</h1>
+      <p class="meta">Entity · Updated 2026-05-27 · Confidence: high</p>
+      <div class="wiki-tags"><span>company</span><span>company</span><span>strategy</span></div>
+      <div class="wiki-content">
+<p>Y Combinator is the startup accelerator behind the How to Start a Startup lecture series. In this wiki, it is a source of founder/operator mental models rather than a general company profile.</p>
+      </div>
+    </article>
+
+    <footer>
+      <span>Generated from Jay's public wiki export</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/index.html
+++ b/wiki/index.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Jay Sosa Wiki</title>
+    <meta name="description" content="A public map of concepts, companies, people, markets, and operating ideas Jeison Sosa is learning from.">
+    <meta name="author" content="Jeison Sosa">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="canonical" href="https://jsosa.xyz/wiki/">
+    <link rel="stylesheet" href="../style.css">
+    <link rel="stylesheet" href="wiki.css">
+  </head>
+  <body class="wiki-home">
+    <header>
+      <h1>Wiki</h1>
+      <p class="subtitle">Concepts · entities · operating ideas</p>
+      <hr class="header-rule">
+    </header>
+
+    <section>
+      <h2>About</h2>
+      <p>A public map of concepts, companies, people, markets, and operating ideas I am learning from. It is generated from my private markdown knowledge base, with personal notes and raw sources removed.</p>
+      <p class="wiki-counts"><a href="concepts/index.html">44 concepts</a> · <a href="entities/index.html">35 entities</a></p>
+    </section>
+
+    <section>
+      <h2>Featured concepts</h2>
+      <div class="wiki-card-list">
+        <a class="wiki-card" href="concepts/ai-founder-mode.html">
+          <span class="wiki-card-title">AI Founder Mode</span>
+          <span class="wiki-card-description">Brian Chesky describes founder mode as the founder/CEO staying close enough to the work to steer the company, rather than over-delegating to professional managers and being managed by the organisation. AI founder...</span>
+        </a>
+        <a class="wiki-card" href="concepts/ai-era-product-management.html">
+          <span class="wiki-card-title">AI-era Product Management</span>
+          <span class="wiki-card-description">Gokul Rajaram argues that AI changes product management because software is becoming faster, cheaper, and less deterministic to build. The durable human role is judgement: choosing what matters, defining the customer...</span>
+        </a>
+        <a class="wiki-card" href="concepts/ai-native-software-business-models.html">
+          <span class="wiki-card-title">AI-native Software Business Models</span>
+          <span class="wiki-card-description">Gokul Rajaram&#x27;s AI-software thesis is that thin AI features are fragile, but AI-native companies can be durable when they own scarce assets, deep workflows, systems of record, data loops, regulated control points,...</span>
+        </a>
+        <a class="wiki-card" href="concepts/software-moats.html">
+          <span class="wiki-card-title">Software Moats</span>
+          <span class="wiki-card-description">Gokul Rajaram&#x27;s 20VC framework lists eight moats for enduring software companies. The key rule is cumulative: one moat is weak; four or more moats suggest a company is relatively safe from competition; zero moats...</span>
+        </a>
+        <a class="wiki-card" href="concepts/monopoly-theory.html">
+          <span class="wiki-card-title">Monopoly Theory</span>
+          <span class="wiki-card-description">Peter Thiel&#x27;s lecture argues that valuable companies both create value and capture part of it. Competition destroys capture; monopoly enables durable profit, long-term thinking, and reinvestment. Thiel&#x27;s practical...</span>
+        </a>
+        <a class="wiki-card" href="concepts/doing-things-that-do-not-scale.html">
+          <span class="wiki-card-title">Doing Things That Do Not Scale</span>
+          <span class="wiki-card-description">Doing things that do not scale means deliberately using manual, high-touch, or messy actions early because they create learning, quality, and momentum before automation is justified. Stanley Tang describes the early...</span>
+        </a>
+        <a class="wiki-card" href="concepts/startup-operating-and-management.html">
+          <span class="wiki-card-title">Startup Operating and Management</span>
+          <span class="wiki-card-description">Operating is the work of turning a product into a company. keith-rabois frames the company as an engine: early on it is held together with duct tape and heroics; the goal is eventually a high-performance machine that...</span>
+        </a>
+        <a class="wiki-card" href="concepts/founder-psychology-and-fit.html">
+          <span class="wiki-card-title">Founder Psychology and Fit</span>
+          <span class="wiki-card-description">Founder fit is the alignment between a founder, a problem, and the long psychological commitment needed to build a company. The YC lectures repeatedly warn that startups are harder, longer, and less glamorous than...</span>
+        </a>
+        <a class="wiki-card" href="concepts/product-delight-and-craft.html">
+          <span class="wiki-card-title">Product Delight and Craft</span>
+          <span class="wiki-card-description">Kevin Hale&#x27;s lecture gives a craft-level version of building-products-users-love: products create emotional relationships with users through first impressions, small details, support, and long-term trust. Hale&#x27;s...</span>
+        </a>
+      </div>
+    </section>
+
+    <section>
+      <h2>Recently updated</h2>
+      <div class="wiki-card-list compact">
+        <a class="wiki-card" href="concepts/ai-era-product-management.html">
+          <span class="wiki-card-title">AI-era Product Management</span>
+          <span class="wiki-card-description">Gokul Rajaram argues that AI changes product management because software is becoming faster, cheaper, and less deterministic to build. The durable human role is judgement: choosing what matters, defining the customer...</span>
+        </a>
+        <a class="wiki-card" href="concepts/ai-founder-mode.html">
+          <span class="wiki-card-title">AI Founder Mode</span>
+          <span class="wiki-card-description">Brian Chesky describes founder mode as the founder/CEO staying close enough to the work to steer the company, rather than over-delegating to professional managers and being managed by the organisation. AI founder...</span>
+        </a>
+        <a class="wiki-card" href="concepts/ai-native-software-business-models.html">
+          <span class="wiki-card-title">AI-native Software Business Models</span>
+          <span class="wiki-card-description">Gokul Rajaram&#x27;s AI-software thesis is that thin AI features are fragile, but AI-native companies can be durable when they own scarce assets, deep workflows, systems of record, data loops, regulated control points,...</span>
+        </a>
+        <a class="wiki-card" href="concepts/barrels-and-ammunition.html">
+          <span class="wiki-card-title">Barrels and Ammunition</span>
+          <span class="wiki-card-description">Barrels and ammunition is keith-rabois&#x27;s hiring and team-design metaphor. A barrel can take an idea, aim it, assemble the people needed, and ship the outcome. Ammunition is high-quality talent that needs a barrel to...</span>
+        </a>
+        <a class="wiki-card" href="concepts/blood-sugar-balancing-for-metabolic-health.html">
+          <span class="wiki-card-title">Blood Sugar Balancing for Metabolic Health</span>
+          <span class="wiki-card-description">Deering argues that metabolic healing depends on stable fuel availability. Low blood sugar triggers adrenaline, cortisol, and glucagon; excessive spikes trigger insulin and storage. The goal is a steady, warm, calm...</span>
+        </a>
+        <a class="wiki-card" href="concepts/contested-nutrition-claims-kate-deering.html">
+          <span class="wiki-card-title">Contested Nutrition Claims — Kate Deering</span>
+          <span class="wiki-card-description">This page tracks claims from kate-deering&#x27;s How to Heal Your Metabolism that are useful to understand but should not be treated as settled medical or nutritional consensus. Treat the book as a hypothesis-generating...</span>
+        </a>
+        <a class="wiki-card" href="concepts/conviction-consequence-delegation.html">
+          <span class="wiki-card-title">Conviction-Consequence Delegation</span>
+          <span class="wiki-card-description">The conviction-consequence framework, attributed in the source to lessons keith-rabois learned from peter-thiel, is a delegation model for deciding when a leader should let someone else decide and when they must...</span>
+        </a>
+        <a class="wiki-card" href="concepts/eleven-star-experience.html">
+          <span class="wiki-card-title">Eleven-Star Experience</span>
+          <span class="wiki-card-description">Brian Chesky&#x27;s eleven-star exercise is a product imagination tool. Instead of asking what a normal five-star experience looks like, the team pushes the experience into absurd six-, seven-, eight-, nine-, and ten-star...</span>
+        </a>
+        <a class="wiki-card" href="concepts/enterprise-software-startups.html">
+          <span class="wiki-card-title">Enterprise Software Startups</span>
+          <span class="wiki-card-description">Enterprise software startups exploit technology and business-model discontinuities in how organisations work. Aaron Levie&#x27;s Box lecture argues that enterprise software became attractive because cloud, mobile, cheaper...</span>
+        </a>
+        <a class="wiki-card" href="concepts/fragmented-industry-vertical-integration.html">
+          <span class="wiki-card-title">Fragmented Industry Vertical Integration</span>
+          <span class="wiki-card-description">The source summarises a Rabois startup-success formula: find a large, highly fragmented industry with low NPS, then vertically integrate a simpler product or experience. The opportunity is strongest when: A...</span>
+        </a>
+        <a class="wiki-card" href="concepts/how-to-heal-your-metabolism.html">
+          <span class="wiki-card-title">How to Heal Your Metabolism</span>
+          <span class="wiki-card-description">How to Heal Your Metabolism by kate-deering is a book-length, Ray Peat/Broda Barnes-influenced nutrition framework. Its central claim is that health is largely a function of cellular energy production: a robust...</span>
+        </a>
+        <a class="wiki-card" href="concepts/keith-rabois-operating-frameworks.html">
+          <span class="wiki-card-title">Keith Rabois Operating Frameworks</span>
+          <span class="wiki-card-description">This page synthesises a user-provided deep research report on keith-rabois&#x27;s public educational frameworks across lectures, interviews, newsletters, and startup advice. The source frames Rabois&#x27;s operating philosophy...</span>
+        </a>
+      </div>
+    </section>
+
+    <section class="wiki-directory">
+      <h2>Directory</h2>
+      <p><a class="view-all" href="concepts/index.html">Browse concepts</a></p>
+      <p><a class="view-all" href="entities/index.html">Browse entities</a></p>
+    </section>
+
+    <footer>
+      <span>© 2026 Jeison Sosa</span>
+      <a href="/">jsosa.xyz</a>
+    </footer>
+  </body>
+</html>

--- a/wiki/wiki.css
+++ b/wiki/wiki.css
@@ -1,0 +1,125 @@
+/* Public wiki styles. Generated pages also load ../style.css. */
+
+body.wiki-home,
+body.wiki-listing,
+body.wiki-page {
+  max-width: 760px;
+}
+
+.wiki-counts {
+  font-family: 'DM Mono', monospace;
+  font-size: 11px;
+  color: var(--gray);
+  letter-spacing: 0.04em;
+}
+
+.wiki-card-list {
+  display: grid;
+  gap: 0;
+  border-top: 1px solid var(--rule);
+}
+
+.wiki-card {
+  display: block;
+  padding: 16px 0 18px;
+  border-bottom: 1px solid var(--rule);
+}
+
+.wiki-card:hover {
+  border-bottom-color: var(--ink);
+}
+
+.wiki-card-title {
+  display: block;
+  font-size: 15px;
+  line-height: 1.4;
+  margin-bottom: 5px;
+}
+
+.wiki-card-description {
+  display: block;
+  color: var(--gray);
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.wiki-card-list.compact .wiki-card {
+  padding: 10px 0 12px;
+}
+
+.wiki-directory p {
+  margin-bottom: 10px;
+}
+
+.wiki-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: -30px 0 42px;
+}
+
+.wiki-tags span {
+  font-family: 'DM Mono', monospace;
+  font-size: 10px;
+  color: var(--gray);
+  border: 1px solid var(--rule);
+  border-radius: 999px;
+  padding: 2px 7px;
+  letter-spacing: 0.04em;
+}
+
+.wiki-content ul,
+.wiki-content ol {
+  margin: 0 0 22px 22px;
+  padding: 0;
+}
+
+.wiki-content li {
+  margin: 0 0 8px;
+}
+
+.wiki-content blockquote {
+  margin: 28px 0;
+  padding: 0 0 0 18px;
+  border-left: 1px solid var(--rule);
+  color: var(--gray);
+}
+
+.wiki-content code {
+  font-family: 'DM Mono', monospace;
+  font-size: 0.9em;
+}
+
+.wiki-content pre {
+  overflow-x: auto;
+  padding: 16px;
+  border: 1px solid var(--rule);
+  background: rgba(0, 0, 0, 0.025);
+}
+
+.wiki-related {
+  margin-top: 72px;
+}
+
+.wiki-related ul {
+  columns: 2;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.wiki-related li {
+  break-inside: avoid;
+  margin: 0 0 8px;
+  font-size: 14px;
+}
+
+@media (max-width: 640px) {
+  .wiki-related ul {
+    columns: 1;
+  }
+
+  .wiki-tags {
+    margin-top: -24px;
+  }
+}


### PR DESCRIPTION
## Summary
- add generated public wiki pages under /wiki
- add a homepage project link to the public wiki
- include concepts/entities indexes and shared wiki styling

## Validation
- exported 79 pages: 44 concepts and 35 entities
- verified /wiki contains only .html and .css files
- verified generated local links resolve with 0 errors
- searched generated HTML for private/Jay-specific section titles