### PR TITLE
fix: avoid doubled project separators

### DIFF
--- a/style.css
+++ b/style.css
@@ -194,17 +194,16 @@ section:last-of-type {
 
 .project-list {
   margin: 25px 0 0;
+  border-top: 1px solid var(--rule);
 }
 
 .project-item {
   display: block;
   padding: 14px 0 16px;
-  border-top: 1px solid var(--rule);
   border-bottom: 1px solid var(--rule);
 }
 
 .project-item:hover {
-  border-top-color: var(--rule);
   border-bottom-color: var(--ink);
 }
 


### PR DESCRIPTION
## Summary
- Fixes the doubled horizontal separator between homepage project cards
- Moves the top rule to `.project-list` and leaves only bottom rules on `.project-item`

## Validation
- Confirmed `.project-list` owns the top border
- Confirmed `.project-item` no longer has a top border
