### PR TITLE
docs: expand Hermes on my desk essay

### DIFF
--- a/hermes-on-my-desk.html
+++ b/hermes-on-my-desk.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8">
     <title>Hermes on my desk | Jeison Sosa</title>
+    <meta name="description" content="A practical essay on moving Hermes from a VPS to a Mac mini, backing up the useful state to GitHub, and treating an agent as local infrastructure.">
     <meta name="author" content="Jeison Sosa">
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <link rel="stylesheet" href="style.css">
@@ -14,27 +15,93 @@
       <h1>Hermes on my desk</h1>
       <p class="meta">26 May 2026</p>
 
-      <p>At first, Hermes lived on a small Hostinger VPS. That made sense. It was cheap, always on, and far enough away that I could treat it like infrastructure rather than another app on my laptop.</p>
+      <p>Hermes started in the place most small pieces of internet infrastructure start: a cheap server somewhere else. A Hostinger VPS was good enough for the first version because it was always on, easy to reach from Telegram, and separate from the laptop I use every day. That distance was useful at the beginning, because it let me treat the agent as infrastructure rather than another local app I needed to nurse.</p>
 
-      <p>The problem was ownership. I already rely on OpenAI and Claude, and I accept that some of my data moves through their systems when I use their models. With the VPS, there was a third party in the middle as well: the host running the machine that held the agent, the logs, the files, and the routines.</p>
+      <p>The problem was that Hermes was not meant to stay as a chatbot on a remote machine. The useful version of an agent is close to the work: it can read the right folders, edit the right repo, remember the right preferences, run scheduled jobs, and connect small tools that would otherwise sit apart. Once Hermes moved from answering questions to acting on my behalf, the machine it lived on started to matter more.</p>
 
-      <p>That started to feel wrong. The whole point of Hermes was not just to chat, but to act: read local files, edit projects, remember preferences, run scheduled tasks, and connect different parts of my work. If an agent is going to sit that close to your life, the machine matters.</p>
+      <p>I already accept that model calls may pass through OpenAI, Anthropic, or whichever provider I choose for a task. That is one trust boundary. The VPS added another one: the host also held the runtime, logs, files, skills, cron jobs, and the operational state of the agent. That began to feel like the wrong default for a system that was slowly becoming personal infrastructure.</p>
 
-      <p>So I moved it to a Mac mini. The migration was not grand. It was the plain work of copying config, moving skills, restoring memories, checking cron jobs, wiring Telegram again, and making sure the same agent could wake up in a new place without losing its shape.</p>
+      <p>The answer was not a grand self-hosting project. I moved Hermes to a Mac mini on my desk, where the machine is boring, visible, and close to the files it needs to touch. The change was small in hardware terms, but it changed the feeling of the system: the agent stopped being a service I rented and became a local operator I could inspect, restart, patch, and back up.</p>
 
-      <p>The Mac mini changed the feeling of the system. Hermes became part of the room: a small box on my desk with my files beside it, my repos within reach, and the gateway open through Telegram. I could restart it, patch it, inspect it, and know where the work was happening.</p>
+      <figure class="simple-figure">
+        <div class="simple-flow" aria-label="Hermes runs locally, syncs durable state to GitHub, and is reached through Telegram">
+          <span>Mac mini</span>
+          <span>→</span>
+          <span>Hermes state</span>
+          <span>→</span>
+          <span>GitHub sync</span>
+          <span>→</span>
+          <span>restore point</span>
+        </div>
+        <figcaption>The agent runs locally. GitHub is the safety rail, not the primary runtime.</figcaption>
+      </figure>
 
-      <p>GitHub sync became the safety rail. The agent now backs up the parts that matter: config, skills, memories, cron definitions, and project state that should survive a bad update or a dead disk. It is not glamorous, but it is the difference between a toy and a tool you can trust.</p>
+      <h2>What actually moved</h2>
 
-      <p>The sync also makes the system easier to reason about. Changes are not just hidden inside a local folder. They become commits, diffs, and a history of how the agent has changed over time.</p>
+      <p>The migration was ordinary in the way most useful infrastructure work is ordinary. I copied configuration, restored skills, moved memories, checked scheduled jobs, wired Telegram again, and tested whether the same agent could wake up in a new place without losing its shape. None of those steps is interesting alone; together they decide whether a tool survives contact with real use.</p>
 
-      <p>The Press Library added another layer. Instead of asking one model to know the whole web, Hermes can pick up small tools for specific corners of it: Substack, Airbnb, Booking, Food52, and whatever gets added next. It turns the agent from a chat box into a workbench.</p>
+      <p>The important thing was preserving the parts that make Hermes mine rather than reinstalling the software and calling it done. The binary can be reinstalled, the models can change, and the gateway can be restarted. The useful state is the small layer of preferences, workflows, scripts, project conventions, cron definitions, and local context that turns a generic agent into something that understands the room.</p>
 
-      <p>Most of the value has come from ordinary work. We have edited this site, opened pull requests, built backup routines, fixed cron delivery, drafted essays, and started shaping company-performance trackers. None of it feels dramatic on its own. Together it lowers the cost of doing small, useful things.</p>
+      <pre><code>~/.hermes/
+  config.yaml          # runtime shape, providers, tools
+  skills/              # reusable workflows and local conventions
+  cron/                # scheduled jobs and delivery rules
+  memories/            # durable preferences and environment notes
+  projects/            # working repos Hermes is allowed to touch
+  scripts/             # small operators: backup, sync, checks
+  .env                 # secrets stay local and out of commits</code></pre>
 
-      <p>That is the real shift. Hermes is not a second brain. It is closer to a patient operator: close enough to the work, grounded enough in the tools, and persistent enough to keep going while the idea is still warm.</p>
+      <p>That folder structure is not special, but seeing it plainly helped me reason about the system. Hermes is not one thing; it is a runtime plus a memory layer plus a set of skills plus the projects it can act on. The migration worked when those pieces could be named, copied, checked, and restored without depending on a half-remembered setup session.</p>
 
-      <p>The question is no longer whether an agent can help. It is where it should live, what it should remember, and which parts of your life are worth putting within reach.</p>
+      <p>This is also where running locally helps. A local agent can be given a clear boundary: these folders are in reach, those secrets stay out of Git, this repo can be edited, that profile should not be touched, this cron job may send Telegram messages, and this one should stay quiet unless it fails. The point is not that local is magically safe; it is that the boundary is legible.</p>
+
+      <h2>The safety rail</h2>
+
+      <p>Putting Hermes on a Mac mini made the system feel more owned, but it also made backups more important. A server provider gives you a certain kind of persistence by default: the machine is somewhere else, usually online, and usually backed by someone else's disks. A small box on a desk gives you control, but it also gives you a single physical thing that can fail.</p>
+
+      <p>GitHub sync became the safety rail. The agent backs up the durable pieces of its state into a private repository, using commits as checkpoints rather than treating a hidden local directory as the only copy. That means a bad update, broken config change, or dead disk should be recoverable from a history I can inspect.</p>
+
+      <pre><code>git add config.yaml skills/ cron/ memories/ scripts/
+
+if ! git diff --cached --quiet; then
+  git commit -m "sync hermes state"
+  git push origin master
+fi</code></pre>
+
+      <p>The exact script is less important than the rule behind it: commit what helps the agent recover, exclude what should remain secret, and stay quiet when nothing changed. A good backup routine should not become another notification stream. It should disappear on success and only interrupt when the safety rail itself is broken.</p>
+
+      <p>Commits also make the agent easier to trust because changes stop being invisible. A new skill, a changed cron job, a patched workflow, or a modified project note becomes a diff. That is a familiar form of accountability: not perfect, not enough on its own, but far better than a pile of mutable local state with no memory of how it got there.</p>
+
+      <h2>The agent as a workbench</h2>
+
+      <p>Once the runtime and backup loop were stable, the useful part was not the novelty of having an agent on a desk. It was the way Hermes could pick up small tools and use them against real work. We edited this site, debugged cron delivery, opened pull requests, searched for accommodation, drafted essays, and started turning company-performance questions into reusable trackers.</p>
+
+      <p>The Press Library made that pattern clearer. Instead of asking one model to know every website, Hermes can use small browser tools for specific corners of the internet: Substack, Airbnb, Booking, Food52, and whatever comes next. The agent becomes less like a single clever answer box and more like a bench with labelled tools on it.</p>
+
+      <figure class="simple-figure">
+        <div class="simple-stack" aria-label="Hermes workbench layers">
+          <span>conversation</span>
+          <span>tools</span>
+          <span>files</span>
+          <span>memory</span>
+          <span>scheduled work</span>
+        </div>
+        <figcaption>The useful layer is the combination: a chat surface connected to files, tools, memory, and routines.</figcaption>
+      </figure>
+
+      <p>That combination is why the Mac mini matters. A browser-only assistant can help think through a task, but it usually stops at the boundary of action. A local Hermes can inspect the repo, patch the file, run the test, check the browser, remember the convention, and schedule the follow-up. Each action is small; the value comes from not having to rebuild the context every time.</p>
+
+      <p>The system still needs restraint. An agent close to the work should not be allowed to become a vague omnipotent helper with access to everything. It should have specific skills, visible files, testable scripts, and habits that can be corrected. The best version is not magical; it is a patient operator with a clear desk.</p>
+
+      <h2>What I would keep</h2>
+
+      <p>If I were starting again, I would still begin remotely because a VPS is the fastest way to prove that the interface and habits are useful. Telegram delivery, scheduled tasks, and a few simple tools are enough to test whether the agent deserves a permanent place. Moving too early would have turned the setup into a hardware project before the workflow had earned it.</p>
+
+      <p>But I would move the durable version local sooner. Once an agent starts touching personal projects, remembering preferences, editing files, and accumulating routines, its home becomes part of the product. The decision is less about performance and more about accountability: where the files live, how they are backed up, who can inspect the changes, and how quickly the system can be rebuilt.</p>
+
+      <p>The simple version is enough for now. Hermes runs on a Mac mini, speaks through Telegram, keeps its useful state in plain folders, backs up the recoverable parts to GitHub, and uses small tools for specific jobs. That shape is easy to understand after time away, which is the test I care about most.</p>
+
+      <p>The question is no longer whether an agent can help. It is where the agent should live, what it should remember, which tools it should be trusted to use, and which parts of your life are worth putting within reach. For me, the answer is a small machine on the desk, a private backup trail, and an agent close enough to the work to be useful without becoming mysterious.</p>
     </article>
 
     <footer>


### PR DESCRIPTION
## Summary
- Expands `hermes-on-my-desk.html` into a fuller essay matching the public wiki article style
- Adds section headings, two simple figures, and two code snippets
- Keeps the existing shared site styling and article width

## Verification
- Parsed HTML successfully
- Checked article structure: 20 paragraphs, 4 h2 sections, 2 figures, 2 code blocks
- Checked no short/dangling one-sentence body paragraphs
- Previously verified local browser rendering with no visible layout issues