### PR TITLE
fix: tighten header rhythm

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -72,6 +72,10 @@ typeScale:
 spacing:
   pageXDesktop: "20px gutter inside min(100% - 40px, max width)"
   pageXMobile: "16px gutter inside min(100% - 32px, max width)"
+  headerMinHeightDesktop: "26vh"
+  headerMinHeightMobile: "26vh"
+  headerPaddingDesktop: "54px 0 44px"
+  headerPaddingMobile: "30px 0 34px"
   sectionGap: "86px desktop, 68px under 900px"
   cardGap: "10px between cards"
   cardPadding: "16px to 18px"
@@ -230,6 +234,8 @@ Under `900px`, sections collapse into a single column. Under `640px`, use a `32p
 Spacing should feel deliberate and calm.
 
 - Page gutters: `40px` total desktop, `32px` total mobile.
+- Header rhythm: `26vh` min-height on desktop and mobile. Do not reintroduce tall hero-style headers.
+- Header padding: `54px 0 44px` on desktop and `30px 0 34px` on mobile.
 - Section rhythm: generous vertical separation between content groups.
 - Card grid gap: `10px`.
 - Card padding: `16px` or `18px`.

--- a/profitable.html
+++ b/profitable.html
@@ -385,8 +385,8 @@
     }
 
     header {
-      min-height: 46vh;
-      padding: 54px 0 80px;
+      min-height: 26vh;
+      padding: 54px 0 44px;
       margin-bottom: 0;
       border-top: 0;
     }
@@ -528,11 +528,6 @@
         padding: 0 20px;
       }
 
-      header {
-        padding: 54px 0 44px;
-        margin-bottom: 0;
-      }
-
       .form-grid,
       .metrics-grid {
         grid-template-columns: 1fr;
@@ -552,6 +547,14 @@
 
       button {
         width: 100%;
+      }
+    }
+
+    @media (max-width: 640px) {
+      header {
+        min-height: 26vh;
+        padding: 30px 0 34px;
+        margin-bottom: 0;
       }
     }
   </style>

--- a/style.css
+++ b/style.css
@@ -48,7 +48,7 @@ body:not(.site-home):not(.wiki-home):not(.wiki-listing) {
 /* Header */
 
 header {
-  min-height: 46vh;
+  min-height: 26vh;
   padding: 54px 0 44px;
   display: flex;
   flex-direction: column;
@@ -733,8 +733,8 @@ footer a:hover {
   }
 
   header {
-    min-height: 38vh;
-    padding: 34px 0 38px;
+    min-height: 26vh;
+    padding: 30px 0 34px;
   }
 
   h1 {


### PR DESCRIPTION
## Summary
- Reduce global header min-height from hero-style proportions to 26vh
- Tighten mobile header padding and keep profitable page aligned
- Document the header rhythm in DESIGN.md

## Test Plan
- git diff --check
- python3 HTMLParser smoke parse for index.html and profitable.html